### PR TITLE
Migrate Metal GPU backend to objc2 (v0.12.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Guidance for coding agents working in `diffusionx`.
 
 - Language: Rust (edition `2024`).
 - Crate: `diffusionx`.
-- MSRV: `1.87` (`rust-version` in `Cargo.toml`).
+- MSRV: `1.88` (`rust-version` in `Cargo.toml`).
 - Library doctests: disabled (`[lib] doctest = false`).
 - Default feature: `mimalloc`.
 - Optional features: `cuda`, `metal`, `io`, `visualize`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Companion file
+
+`AGENTS.md` holds the exhaustive command list and the project's style/design conventions
+(imports, naming, error handling, parallelism, feature gating, testing expectations).
+Read it for any non-trivial change. This file covers the essentials and the big-picture
+architecture.
+
+## Common commands
+
+```sh
+cargo build                          # default features (mimalloc only)
+cargo check --all
+cargo clippy --all-targets --tests --benches -- -D warnings
+cargo fmt -- --check
+cargo test                           # library tests; doctests are disabled
+cargo test --features "visualize,io" # feature-gated code paths
+
+# Single test
+cargo test test_simulate_bm                      # by name substring
+cargo test simulation::continuous::bm::tests     # by module path
+cargo test test_simulate_bm -- --exact --nocapture
+
+cargo run --example bm               # examples: bm, langevin, randoms, CIR
+cargo bench --bench bm               # benches: bm, ou, random, levy (Criterion)
+```
+
+GPU builds require a toolchain and are feature-gated: `cargo build --features cuda`
+(needs `nvcc`) or `cargo build --features metal` (needs Xcode). `cuda` and `metal` are
+mutually exclusive — `build.rs` panics if both are enabled.
+
+Pre-commit (`.pre-commit-config.yaml`) runs `cargo fmt --check`, `cargo check --all`, and
+the clippy command above. CI (`.github/workflows/test.yml`) runs build + test only.
+
+## Architecture
+
+DiffusionX is a Rust library (edition 2024, MSRV 1.88) for random number generation and
+stochastic process simulation. The design is trait-based: implement one base trait + a `simulate` method and
+a process gets the full suite of observables (moments, first passage time, occupation
+time, TAMSD, plotting) for free via default trait methods.
+
+### Trait + trajectory layering
+
+- **`src/simulation/basic/`** — the core abstractions: base traits `ContinuousProcess`,
+  `PointProcess`, `DiscreteProcess`; the `Moment` trait; `tamsd`, `inverse`, `functional`
+  helpers. Concrete process structs live in **`continuous/`**, **`discrete/`**, **`point/`**
+  and implement these traits.
+- A bare process (e.g. `Bm`) only knows how to `simulate` a single path. Ensemble
+  statistics work through a **trajectory**: `process.duration(t)` returns a
+  `ContinuousTrajectory` (likewise `DiscreteTrajectory`, `PointTrajectory`). The `Moment`
+  trait is implemented on the *trajectory* types, not the processes — so `mean`, `msd`,
+  `raw_moment`, fractional moments, etc. are reached via `.duration(t)?` first.
+- `ContinuousProcess` also exposes convenience methods (`mean`, `msd`, `fpt`, `eatamsd`…)
+  that internally build a trajectory; these carry a `where Self: ContinuousTrajectoryTrait`
+  bound.
+
+### Numeric generics
+
+`src/lib.rs` defines three blanket-implemented trait aliases — `FloatExt` (float-only
+processes), `IntExt` (discrete integer states), `RealExt` (int-or-float state values).
+Use these bounds rather than re-listing `num_traits` requirements. Continuous processes
+are generic over `T: FloatExt` and default to `f64`.
+
+### Errors
+
+`src/error.rs` defines `XError` (the crate-wide error enum), `StableError`,
+`SimulationError`, the `XResult<T>` alias, and validation helpers like
+`check_duration_time_step`. Public fallible APIs return `XResult<T>`.
+
+### Feature-gated modules
+
+- `visualize` — `src/visualize/`, plotting via `plotters`; adds `Visualize`/`plot`.
+- `io` — CSV helpers in `src/utils/csv.rs`.
+- `cuda` / `metal` — `src/gpu/{cuda,metal}/`. `build.rs` compiles the kernel sources in
+  `kernels/cuda-kernel/*.cu` (→ PTX via `nvcc`) or `kernels/metal-kernel/*.metal`
+  (→ metallib via `xcrun`) and passes the artifact paths to the crate as env vars
+  (e.g. `BM_KERNEL_PTX`, `BM_KERNEL_METALLIB`). The `GPUMoment` trait operates on `f32`
+  and is implemented only for `Bm`, `OrnsteinUhlenbeck`, and `Levy`.
+- `mimalloc` (default) — sets the global allocator.
+
+### Other notes
+
+- RNG: all distributions share a Xoshiro256++ entropy source. Modules in `src/random/`
+  expose free functions (`rand`, `rands`, `standard_rands`, …).
+- `langevin!`, `generalized_langevin!`, `subordinated_langevin!`
+  (`src/simulation/macros.rs`) are `#[macro_export]`ed DSL-style constructors available
+  at the crate root.
+- Parallelism uses `rayon`; loops switch between sequential and parallel based on a
+  `PAR_THRESHOLD`. Keep that pattern when adding ensemble computations.
+- The crate's rustdoc landing page is `README.md` (included via `#![doc = include_str!]`),
+  so README changes affect generated docs.
+
+To add a new continuous process, implement `ContinuousProcess` (define `start` and
+`simulate`); the moment/FPT/TAMSD/plot machinery comes from default methods. See
+`examples/CIR.rs` for a worked example.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "diffusionx"
 
 [features]
 cuda = ["dep:cudarc"]
-default = ["metal", "mimalloc"]
+default = ["mimalloc"]
 io = ["dep:csv"]
 metal = ["dep:metal"]
 mimalloc = ["dep:mimalloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,11 @@ mimalloc = { version = "0.1", optional = true }
 num-complex = "0.4"
 num-traits = "0.2"
 objc2 = { version = "0.6", optional = true }
-objc2-foundation = { version = "0.3", optional = true, features = ["NSError", "NSString"] }
+objc2-foundation = { version = "0.3", optional = true, features = [
+    "NSError",
+    "NSString",
+    "NSURL",
+] }
 objc2-metal = { version = "0.3", optional = true }
 plotters = { version = "0.3", optional = true }
 plotters-backend = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "diffusionx"
 readme = "README.md"
 repository = "https://github.com/tangxiangong/diffusionx"
 rust-version = "1.88"
-version = "0.11.5"
+version = "0.12.0"
 
 [package.metadata.docs.rs]
 features = ["io", "visualize"]
@@ -23,7 +23,12 @@ name = "diffusionx"
 cuda = ["dep:cudarc"]
 default = ["mimalloc"]
 io = ["dep:csv"]
-metal = ["dep:objc2", "dep:objc2-foundation", "dep:objc2-metal", "dep:dispatch2"]
+metal = [
+    "dep:dispatch2",
+    "dep:objc2",
+    "dep:objc2-foundation",
+    "dep:objc2-metal",
+]
 mimalloc = ["dep:mimalloc"]
 visualize = [
     "dep:derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "diffusionx"
 cuda = ["dep:cudarc"]
 default = ["mimalloc"]
 io = ["dep:csv"]
-metal = ["dep:metal", "dep:objc2", "dep:objc2-foundation", "dep:objc2-metal"]
+metal = ["dep:objc2", "dep:objc2-foundation", "dep:objc2-metal"]
 mimalloc = ["dep:mimalloc"]
 visualize = [
     "dep:derive_builder",
@@ -40,12 +40,11 @@ cudarc = { version = "0.19", optional = true, features = [
 derive_builder = { version = "0.20", optional = true }
 either = { version = "1", optional = true }
 gauss-quad = "0.3"
-metal = { version = "0.33", optional = true }
 mimalloc = { version = "0.1", optional = true }
 num-complex = "0.4"
 num-traits = "0.2"
 objc2 = { version = "0.6", optional = true }
-objc2-foundation = { version = "0.3", optional = true, features = ["NSString"] }
+objc2-foundation = { version = "0.3", optional = true, features = ["NSError", "NSString"] }
 objc2-metal = { version = "0.3", optional = true }
 plotters = { version = "0.3", optional = true }
 plotters-backend = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,36 +1,31 @@
 [package]
-name = "diffusionx"
 authors = ["Xiangong Tang <tangxiangong@gmail.com>"]
-edition = "2024"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/tangxiangong/diffusionx"
-categories = ["science", "mathematics"]
-keywords = ["stochastic-process", "simulation", "Monte-Carlo", "gpu"]
-version = "0.11.5"
+categories = ["mathematics", "science"]
 description = "A multi-threaded crate for random number generation and stochastic process simulation, with optional GPU acceleration."
+edition = "2024"
+keywords = ["Monte-Carlo", "gpu", "simulation", "stochastic-process"]
+license = "MIT OR Apache-2.0"
+name = "diffusionx"
 readme = "README.md"
+repository = "https://github.com/tangxiangong/diffusionx"
 rust-version = "1.87"
+version = "0.11.5"
 
 [package.metadata.docs.rs]
-features = ["visualize", "io"]
-rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "./docs-header.html"]
+features = ["io", "visualize"]
+rustdoc-args = ["--cfg", "--html-in-header", "./docs-header.html", "docsrs"]
 
 [lib]
-name = "diffusionx"
 doctest = false
+name = "diffusionx"
 
 [features]
-default = ["mimalloc"]
 cuda = ["dep:cudarc"]
-mimalloc = ["dep:mimalloc"]
-metal = ["dep:metal"]
+default = ["metal", "mimalloc"]
 io = ["dep:csv"]
-visualize = [
-    "dep:plotters",
-    "dep:derive_builder",
-    "dep:plotters-backend",
-    "dep:either",
-]
+metal = ["dep:metal"]
+mimalloc = ["dep:mimalloc"]
+visualize = ["dep:derive_builder", "dep:either", "dep:plotters", "dep:plotters-backend"]
 
 [dependencies]
 csv = { version = "1.4", optional = true }
@@ -60,38 +55,38 @@ criterion = "0.8"
 # See: https://github.com/rust-lang/rust/issues/147399
 # Disable scrape-examples for all example targets
 [[example]]
+doc-scrape-examples = false
 name = "CIR"
-doc-scrape-examples = false
 
 [[example]]
+doc-scrape-examples = false
 name = "bm"
-doc-scrape-examples = false
 
 [[example]]
+doc-scrape-examples = false
 name = "langevin"
-doc-scrape-examples = false
 
 [[example]]
-name = "randoms"
 doc-scrape-examples = false
+name = "randoms"
 
 [profile.release]
-lto = true
 codegen-units = 1
+lto = true
 panic = "abort"
 
 [[bench]]
+harness = false
 name = "bm"
-harness = false
 
 [[bench]]
+harness = false
 name = "ou"
-harness = false
 
 [[bench]]
+harness = false
 name = "random"
-harness = false
 
 [[bench]]
-name = "levy"
 harness = false
+name = "levy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "diffusionx"
 cuda = ["dep:cudarc"]
 default = ["mimalloc"]
 io = ["dep:csv"]
-metal = ["dep:objc2", "dep:objc2-foundation", "dep:objc2-metal"]
+metal = ["dep:objc2", "dep:objc2-foundation", "dep:objc2-metal", "dep:dispatch2"]
 mimalloc = ["dep:mimalloc"]
 visualize = [
     "dep:derive_builder",
@@ -38,6 +38,7 @@ cudarc = { version = "0.19", optional = true, features = [
     "cuda-version-from-build-system",
 ] }
 derive_builder = { version = "0.20", optional = true }
+dispatch2 = { version = "0.3", optional = true }
 either = { version = "1", optional = true }
 gauss-quad = "0.3"
 mimalloc = { version = "0.1", optional = true }
@@ -47,7 +48,6 @@ objc2 = { version = "0.6", optional = true }
 objc2-foundation = { version = "0.3", optional = true, features = [
     "NSError",
     "NSString",
-    "NSURL",
 ] }
 objc2-metal = { version = "0.3", optional = true }
 plotters = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "diffusionx"
 cuda = ["dep:cudarc"]
 default = ["mimalloc"]
 io = ["dep:csv"]
-metal = ["dep:metal"]
+metal = ["dep:metal", "dep:objc2", "dep:objc2-foundation", "dep:objc2-metal"]
 mimalloc = ["dep:mimalloc"]
 visualize = [
     "dep:derive_builder",
@@ -44,6 +44,9 @@ metal = { version = "0.33", optional = true }
 mimalloc = { version = "0.1", optional = true }
 num-complex = "0.4"
 num-traits = "0.2"
+objc2 = { version = "0.6", optional = true }
+objc2-foundation = { version = "0.3", optional = true, features = ["NSString"] }
+objc2-metal = { version = "0.3", optional = true }
 plotters = { version = "0.3", optional = true }
 plotters-backend = { version = "0.3", optional = true }
 rand = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "diffusionx"
 readme = "README.md"
 repository = "https://github.com/tangxiangong/diffusionx"
-rust-version = "1.87"
+rust-version = "1.88"
 version = "0.11.5"
 
 [package.metadata.docs.rs]
@@ -25,7 +25,12 @@ default = ["mimalloc"]
 io = ["dep:csv"]
 metal = ["dep:metal"]
 mimalloc = ["dep:mimalloc"]
-visualize = ["dep:derive_builder", "dep:either", "dep:plotters", "dep:plotters-backend"]
+visualize = [
+    "dep:derive_builder",
+    "dep:either",
+    "dep:plotters",
+    "dep:plotters-backend",
+]
 
 [dependencies]
 csv = { version = "1.4", optional = true }

--- a/benches/random.rs
+++ b/benches/random.rs
@@ -24,6 +24,13 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
+    #[cfg(feature = "metal")]
+    c.bench_function("uniform distribution f32 (metal)", |b| {
+        b.iter(|| {
+            let _ = diffusionx::gpu::random::rand(black_box(N)).unwrap();
+        })
+    });
+
     c.bench_function("normal distribution f64", |b| {
         b.iter(|| {
             let _ = normal::standard_rands::<f64>(black_box(N));
@@ -38,6 +45,14 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     #[cfg(feature = "cuda")]
     c.bench_function("normal distribution f32 (cuda)", |b| {
+        b.iter(|| {
+            let _ = diffusionx::gpu::random::randn(black_box(N), black_box(0.0), black_box(1.0))
+                .unwrap();
+        })
+    });
+
+    #[cfg(feature = "metal")]
+    c.bench_function("normal distribution f32 (metal)", |b| {
         b.iter(|| {
             let _ = diffusionx::gpu::random::randn(black_box(N), black_box(0.0), black_box(1.0))
                 .unwrap();
@@ -63,6 +78,13 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
+    #[cfg(feature = "metal")]
+    c.bench_function("exponential distribution f32 (metal)", |b| {
+        b.iter(|| {
+            let _ = diffusionx::gpu::random::randexp(black_box(N)).unwrap();
+        })
+    });
+
     c.bench_function("stable distribution f64", |b| {
         b.iter(|| {
             let _ = stable::sym_standard_rands(black_box(0.7), black_box(N)).unwrap();
@@ -81,6 +103,18 @@ fn criterion_benchmark(c: &mut Criterion) {
             let _ = diffusionx::gpu::random::standard_stable_rands(
                 black_box(0.7),
                 black_box(0.0),
+                black_box(N),
+            )
+            .unwrap();
+        })
+    });
+
+    #[cfg(feature = "metal")]
+    c.bench_function("stable distribution f32 (metal)", |b| {
+        b.iter(|| {
+            let _ = diffusionx::gpu::random::standard_stable_rands(
+                black_box(0.7f32),
+                black_box(0.0f32),
                 black_box(N),
             )
             .unwrap();

--- a/benches/random.rs
+++ b/benches/random.rs
@@ -20,7 +20,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     #[cfg(feature = "cuda")]
     c.bench_function("uniform distribution f32 (CUDA)", |b| {
         b.iter(|| {
-            let _ = diffusionx::gpu::random::curands(black_box(N)).unwrap();
+            let _ = diffusionx::gpu::random::rand(black_box(N)).unwrap();
         })
     });
 
@@ -39,7 +39,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     #[cfg(feature = "cuda")]
     c.bench_function("normal distribution f32 (cuda)", |b| {
         b.iter(|| {
-            let _ = diffusionx::gpu::random::curandn(black_box(N), black_box(0.0), black_box(1.0))
+            let _ = diffusionx::gpu::random::randn(black_box(N), black_box(0.0), black_box(1.0))
                 .unwrap();
         })
     });
@@ -59,7 +59,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     #[cfg(feature = "cuda")]
     c.bench_function("exponential distribution f32 (cuda)", |b| {
         b.iter(|| {
-            let _ = diffusionx::gpu::random::curandexp(black_box(N)).unwrap();
+            let _ = diffusionx::gpu::random::randexp(black_box(N)).unwrap();
         })
     });
 

--- a/docs/superpowers/plans/2026-05-21-metal-objc2-migration.md
+++ b/docs/superpowers/plans/2026-05-21-metal-objc2-migration.md
@@ -1,0 +1,944 @@
+# Metal objc2 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the deprecated `metal` crate with `objc2-metal` while preserving the existing `metal` Cargo feature and public GPU API.
+
+**Architecture:** Keep the public `diffusionx::gpu::metal` module intact and add a private adapter layer inside `src/gpu/metal/mod.rs`. The adapter owns Objective-C retained objects, `NSString` conversion, buffer allocation, scalar binding, command completion, and all new `unsafe` calls so process modules stay focused on kernel semantics.
+
+**Tech Stack:** Rust 2024, `objc2`, `objc2-foundation`, `objc2-metal`, Apple Metal command APIs, existing `xcrun metal` / `xcrun metallib` build flow.
+
+---
+
+## File Structure
+
+- Modify `Cargo.toml`
+  - Remove the optional `metal` crate dependency.
+  - Add optional `objc2`, `objc2-foundation`, and `objc2-metal` dependencies behind the existing `metal` feature.
+- Modify `Cargo.lock`
+  - Let Cargo update lockfile entries after dependency replacement.
+- Modify `src/gpu/metal/mod.rs`
+  - Replace all direct `metal` crate imports.
+  - Add private objc2-metal type aliases and helper functions.
+  - Port `METAL_DEVICE`, `METAL_QUEUE`, `load_library`, `get_pipeline`, `thread_config`, and the two Metal macros.
+- Modify `src/gpu/metal/random.rs`
+  - Replace direct `metal` crate use with the new helpers.
+  - Keep public function signatures unchanged.
+- Modify `src/gpu/metal/{bm.rs,ou.rs,levy.rs}`
+  - Only adjust concrete library/pipeline type names if needed.
+- Optional modify `README.md`
+  - Only if implementation changes setup requirements. The expected path is no README change.
+
+## Task 1: Dependency Gate
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `Cargo.lock`
+
+- [ ] **Step 1: Update optional dependency metadata**
+
+Edit `Cargo.toml` so the feature and dependency section use:
+
+```toml
+[features]
+cuda = ["dep:cudarc"]
+default = ["mimalloc"]
+io = ["dep:csv"]
+metal = ["dep:objc2", "dep:objc2-foundation", "dep:objc2-metal"]
+mimalloc = ["dep:mimalloc"]
+visualize = [
+    "dep:derive_builder",
+    "dep:either",
+    "dep:plotters",
+    "dep:plotters-backend",
+]
+```
+
+Replace:
+
+```toml
+metal = { version = "0.33", optional = true }
+```
+
+with:
+
+```toml
+objc2 = { version = "0.6", optional = true }
+objc2-foundation = { version = "0.3", optional = true, features = ["NSString"] }
+objc2-metal = { version = "0.3", optional = true }
+```
+
+- [ ] **Step 2: Run metadata check to refresh the lockfile**
+
+Run:
+
+```sh
+cargo check --no-default-features
+```
+
+Expected: PASS. This should not compile the Metal backend, but it should update `Cargo.lock` if needed.
+
+- [ ] **Step 3: Verify no public feature rename happened**
+
+Run:
+
+```sh
+rg -n 'metal = \[' Cargo.toml
+rg -n 'dep:metal|metal = \{ version' Cargo.toml
+```
+
+Expected: first command prints the `metal = ["dep:objc2", ...]` feature; second command prints nothing.
+
+- [ ] **Step 4: Commit dependency metadata**
+
+Run:
+
+```sh
+git add Cargo.toml Cargo.lock
+printf '%s\n' \
+'build(gpu): replace deprecated Metal binding dependency' \
+'' \
+'Summary:' \
+'- remove the optional deprecated metal crate dependency' \
+'- add optional objc2, objc2-foundation, and objc2-metal dependencies behind the existing metal feature' \
+'' \
+'Rationale:' \
+'- prepare the Metal backend migration without changing the public feature name' \
+'- keep replacement bindings optional so default builds remain unaffected' \
+'' \
+'Tests:' \
+'- cargo check --no-default-features' \
+'' \
+'Co-authored-by: Codex <noreply@openai.com>' \
+> /private/tmp/diffusionx-commit.txt
+git commit -F /private/tmp/diffusionx-commit.txt
+```
+
+Commit message content:
+
+```text
+build(gpu): replace deprecated Metal binding dependency
+
+Summary:
+- remove the optional deprecated metal crate dependency
+- add optional objc2, objc2-foundation, and objc2-metal dependencies behind the existing metal feature
+
+Rationale:
+- prepare the Metal backend migration without changing the public feature name
+- keep replacement bindings optional so default builds remain unaffected
+
+Tests:
+- cargo check --no-default-features
+
+Co-authored-by: Codex <noreply@openai.com>
+```
+
+## Task 2: Adapter Types and Device Setup
+
+**Files:**
+- Modify: `src/gpu/metal/mod.rs`
+
+- [ ] **Step 1: Replace imports and add type aliases**
+
+At the top of `src/gpu/metal/mod.rs`, replace the current Metal imports with:
+
+```rust
+use crate::{XError, XResult};
+use objc2::{
+    rc::Retained,
+    runtime::ProtocolObject,
+};
+use objc2_foundation::NSString;
+use objc2_metal::{
+    MTLBuffer, MTLCommandBuffer, MTLCommandQueue, MTLComputeCommandEncoder,
+    MTLComputePipelineState, MTLCreateSystemDefaultDevice, MTLDevice, MTLFunction, MTLLibrary,
+    MTLResourceOptions, MTLSize,
+};
+use std::{ffi::c_void, ptr::NonNull, sync::LazyLock};
+
+type MetalDevice = ProtocolObject<dyn MTLDevice>;
+type MetalQueue = ProtocolObject<dyn MTLCommandQueue>;
+type MetalLibrary = ProtocolObject<dyn MTLLibrary>;
+type MetalFunction = ProtocolObject<dyn MTLFunction>;
+type MetalPipeline = ProtocolObject<dyn MTLComputePipelineState>;
+type MetalBuffer = ProtocolObject<dyn MTLBuffer>;
+type MetalCommandBuffer = ProtocolObject<dyn MTLCommandBuffer>;
+type MetalComputeEncoder = ProtocolObject<dyn MTLComputeCommandEncoder>;
+```
+
+- [ ] **Step 2: Port device and queue statics**
+
+Replace the current `METAL_DEVICE` and `METAL_QUEUE` definitions with:
+
+```rust
+pub(crate) static METAL_DEVICE: LazyLock<XResult<Retained<MetalDevice>>> = LazyLock::new(|| {
+    MTLCreateSystemDefaultDevice()
+        .ok_or_else(|| XError::Other("No Metal device found".into()))
+});
+
+pub(crate) static METAL_QUEUE: LazyLock<XResult<Retained<MetalQueue>>> = LazyLock::new(|| {
+    let device = METAL_DEVICE.as_ref()?;
+    device
+        .newCommandQueue()
+        .ok_or_else(|| XError::Other("Failed to create Metal command queue".into()))
+});
+```
+
+- [ ] **Step 3: Port thread configuration**
+
+Replace `thread_config` with:
+
+```rust
+#[inline]
+pub(crate) fn thread_config(particles: usize) -> (MTLSize, MTLSize) {
+    let thread_group_size = 256usize;
+    let thread_groups = particles.div_ceil(thread_group_size);
+
+    (
+        MTLSize {
+            width: thread_groups,
+            height: 1,
+            depth: 1,
+        },
+        MTLSize {
+            width: thread_group_size,
+            height: 1,
+            depth: 1,
+        },
+    )
+}
+```
+
+- [ ] **Step 4: Compile to expose exact objc2 API mismatches**
+
+Run:
+
+```sh
+cargo check --features metal --no-default-features
+```
+
+Expected: FAIL at remaining old `metal::...` type references and unported methods. If it fails on `MTLSize` integer type, replace `usize` fields with `thread_groups as _` and `thread_group_size as _`.
+
+## Task 3: Library, Pipeline, Buffer, and Command Helpers
+
+**Files:**
+- Modify: `src/gpu/metal/mod.rs`
+
+- [ ] **Step 1: Add NSError formatting helper**
+
+Add below the `.metallib` constants:
+
+```rust
+fn ns_error_message(error: &objc2_foundation::NSError) -> String {
+    error.localizedDescription().to_string()
+}
+```
+
+If `NSError` is not available with the current feature set, update the dependency to:
+
+```toml
+objc2-foundation = { version = "0.3", optional = true, features = ["NSError", "NSString"] }
+```
+
+- [ ] **Step 2: Port `load_library`**
+
+Replace the current function with:
+
+```rust
+pub(crate) fn load_library(path: &str) -> XResult<Retained<MetalLibrary>> {
+    let device = METAL_DEVICE.as_ref()?;
+    let path = NSString::from_str(path);
+
+    device
+        .newLibraryWithFile_error(&path)
+        .map_err(|error| {
+            XError::Other(format!(
+                "Failed to load Metal library '{}': {}",
+                path,
+                ns_error_message(&error)
+            ))
+        })
+}
+```
+
+If `NSString` does not format cleanly with `{}`, use `path.to_string()` before the call and include that Rust string in the error.
+
+- [ ] **Step 3: Port `get_pipeline`**
+
+Replace the current function with:
+
+```rust
+pub(crate) fn get_pipeline(
+    library: &MetalLibrary,
+    function_name: &str,
+) -> XResult<Retained<MetalPipeline>> {
+    let device = METAL_DEVICE.as_ref()?;
+    let function_name_ns = NSString::from_str(function_name);
+    let function: Retained<MetalFunction> = library
+        .newFunctionWithName(&function_name_ns)
+        .ok_or_else(|| XError::Other(format!("Function '{function_name}' not found")))?;
+
+    device
+        .newComputePipelineStateWithFunction_error(&function)
+        .map_err(|error| {
+            XError::Other(format!(
+                "Pipeline creation error for '{function_name}': {}",
+                ns_error_message(&error)
+            ))
+        })
+}
+```
+
+- [ ] **Step 4: Add buffer and encoder helpers**
+
+Add the following helpers before the macros:
+
+```rust
+pub(crate) fn new_shared_buffer(bytes: usize) -> XResult<Retained<MetalBuffer>> {
+    let device = METAL_DEVICE.as_ref()?;
+    device
+        .newBufferWithLength_options(bytes, MTLResourceOptions::StorageModeShared)
+        .ok_or_else(|| XError::Other(format!("Failed to allocate Metal shared buffer: {bytes} bytes")))
+}
+
+pub(crate) fn zero_buffer_f32(buffer: &MetalBuffer) {
+    // SAFETY: `contents` is valid for a shared Metal buffer, and this writes one f32
+    // before the buffer is submitted to the GPU.
+    unsafe {
+        let ptr = buffer.contents().as_ptr().cast::<f32>();
+        ptr.write(0.0);
+    }
+}
+
+pub(crate) fn read_buffer_f32(buffer: &MetalBuffer) -> f32 {
+    // SAFETY: command-buffer completion is awaited before callers read the shared buffer.
+    unsafe { buffer.contents().as_ptr().cast::<f32>().read() }
+}
+
+pub(crate) fn read_buffer_vec_f32(buffer: &MetalBuffer, len: usize) -> Vec<f32> {
+    // SAFETY: command-buffer completion is awaited before callers read `len` f32 values.
+    unsafe {
+        let ptr = buffer.contents().as_ptr().cast::<f32>();
+        std::slice::from_raw_parts(ptr, len).to_vec()
+    }
+}
+
+pub(crate) fn set_buffer(
+    encoder: &MetalComputeEncoder,
+    index: usize,
+    buffer: &MetalBuffer,
+) {
+    // SAFETY: the retained buffer lives until after `waitUntilCompleted`, offset is zero,
+    // and the binding index matches the Metal kernel signature.
+    unsafe {
+        encoder.setBuffer_offset_atIndex(Some(buffer), 0, index);
+    }
+}
+
+pub(crate) fn set_scalar<T>(
+    encoder: &MetalComputeEncoder,
+    index: usize,
+    value: &T,
+) {
+    let ptr = NonNull::from(value).cast::<c_void>();
+    // SAFETY: Metal copies `size_of::<T>()` bytes immediately from a valid stack value,
+    // and scalar bindings are smaller than Metal's inline setBytes limit.
+    unsafe {
+        encoder.setBytes_length_atIndex(ptr, std::mem::size_of::<T>(), index);
+    }
+}
+
+pub(crate) fn finish_command_buffer(command_buffer: &MetalCommandBuffer) -> XResult<()> {
+    command_buffer.commit();
+    command_buffer.waitUntilCompleted();
+
+    if let Some(error) = command_buffer.error() {
+        return Err(XError::Other(format!(
+            "Metal command buffer failed: {}",
+            ns_error_message(&error)
+        )));
+    }
+
+    Ok(())
+}
+```
+
+If objc2 expects `NSUInteger` rather than `usize`, cast every index and length argument with `as _` at the call site inside these helpers.
+
+- [ ] **Step 5: Compile adapter helpers**
+
+Run:
+
+```sh
+cargo check --features metal --no-default-features
+```
+
+Expected: FAIL only in macro/random code still using old method names. Fix helper signatures if the compiler reports exact reference type mismatches, keeping the helper names and responsibilities intact.
+
+## Task 4: Port Moment Macros
+
+**Files:**
+- Modify: `src/gpu/metal/mod.rs`
+
+- [ ] **Step 1: Replace the regular moment macro body**
+
+Inside `subscribe_metal_gpu_function!`, keep the generated function signature unchanged and replace the body with:
+
+```rust
+let queue = $crate::gpu::metal::METAL_QUEUE.as_ref()?;
+static PIPELINE: std::sync::LazyLock<XResult<Retained<MetalPipeline>>> =
+    std::sync::LazyLock::new(|| {
+        let library = $library.as_ref()?;
+        $crate::gpu::metal::get_pipeline(library, $kernel_name)
+    });
+let pipeline = PIPELINE.as_ref()?;
+
+let (thread_groups, threads_per_group) = $crate::gpu::metal::thread_config(particles);
+let out_buffer = $crate::gpu::metal::new_shared_buffer(std::mem::size_of::<f32>())?;
+$crate::gpu::metal::zero_buffer_f32(&out_buffer);
+
+let mut rng = rand::rng();
+use rand::RngExt;
+let seed: u64 = rng.random();
+let particles_u32 = particles as u32;
+
+let command_buffer = queue
+    .commandBuffer()
+    .ok_or_else(|| $crate::XError::Other("Failed to create Metal command buffer".into()))?;
+let encoder = command_buffer
+    .computeCommandEncoder()
+    .ok_or_else(|| $crate::XError::Other("Failed to create Metal compute encoder".into()))?;
+
+encoder.setComputePipelineState(pipeline);
+
+let mut buffer_index = 0usize;
+$crate::gpu::metal::set_buffer(&encoder, buffer_index, &out_buffer);
+buffer_index += 1;
+
+$(
+    $crate::gpu::metal::set_scalar(&encoder, buffer_index, &$param_name);
+    buffer_index += 1;
+)+
+
+$crate::gpu::metal::set_scalar(&encoder, buffer_index, &particles_u32);
+buffer_index += 1;
+$crate::gpu::metal::set_scalar(&encoder, buffer_index, &seed);
+
+encoder.setThreadgroupMemoryLength_atIndex(32 * std::mem::size_of::<f32>(), 0);
+encoder.dispatchThreadgroups_threadsPerThreadgroup(thread_groups, threads_per_group);
+encoder.endEncoding();
+
+$crate::gpu::metal::finish_command_buffer(&command_buffer)?;
+
+let sum = $crate::gpu::metal::read_buffer_f32(&out_buffer);
+Ok(sum / particles as f32)
+```
+
+If the `Retained<MetalPipeline>` type alias is not in macro scope, qualify it as
+`objc2::rc::Retained<$crate::gpu::metal::MetalPipeline>` and make the alias `pub(crate)`.
+
+- [ ] **Step 2: Replace the central moment macro body**
+
+Inside `subscribe_metal_central_moment_gpu_function!`, keep the generated function signature unchanged and replace the body with:
+
+```rust
+let queue = $crate::gpu::metal::METAL_QUEUE.as_ref()?;
+static PIPELINE: std::sync::LazyLock<XResult<Retained<MetalPipeline>>> =
+    std::sync::LazyLock::new(|| {
+        let library = $library.as_ref()?;
+        $crate::gpu::metal::get_pipeline(library, $kernel_name)
+    });
+let pipeline = PIPELINE.as_ref()?;
+
+let (thread_groups, threads_per_group) = $crate::gpu::metal::thread_config(particles);
+let mean_val = mean($($param_name,)+ particles)?;
+let out_buffer = $crate::gpu::metal::new_shared_buffer(std::mem::size_of::<f32>())?;
+$crate::gpu::metal::zero_buffer_f32(&out_buffer);
+
+let mut rng = rand::rng();
+use rand::RngExt;
+let seed: u64 = rng.random();
+let particles_u32 = particles as u32;
+
+let command_buffer = queue
+    .commandBuffer()
+    .ok_or_else(|| $crate::XError::Other("Failed to create Metal command buffer".into()))?;
+let encoder = command_buffer
+    .computeCommandEncoder()
+    .ok_or_else(|| $crate::XError::Other("Failed to create Metal compute encoder".into()))?;
+
+encoder.setComputePipelineState(pipeline);
+
+let mut buffer_index = 0usize;
+$crate::gpu::metal::set_buffer(&encoder, buffer_index, &out_buffer);
+buffer_index += 1;
+$crate::gpu::metal::set_scalar(&encoder, buffer_index, &order);
+buffer_index += 1;
+$crate::gpu::metal::set_scalar(&encoder, buffer_index, &mean_val);
+buffer_index += 1;
+
+$(
+    $crate::gpu::metal::set_scalar(&encoder, buffer_index, &$param_name);
+    buffer_index += 1;
+)+
+
+$crate::gpu::metal::set_scalar(&encoder, buffer_index, &particles_u32);
+buffer_index += 1;
+$crate::gpu::metal::set_scalar(&encoder, buffer_index, &seed);
+
+encoder.setThreadgroupMemoryLength_atIndex(32 * std::mem::size_of::<f32>(), 0);
+encoder.dispatchThreadgroups_threadsPerThreadgroup(thread_groups, threads_per_group);
+encoder.endEncoding();
+
+$crate::gpu::metal::finish_command_buffer(&command_buffer)?;
+
+let sum = $crate::gpu::metal::read_buffer_f32(&out_buffer);
+Ok(sum / particles as f32)
+```
+
+- [ ] **Step 3: Run Metal compile check**
+
+Run:
+
+```sh
+cargo check --features metal --no-default-features
+```
+
+Expected: FAIL only in `src/gpu/metal/random.rs` and process files with old `metal::Library` / `metal::ComputePipelineState` names.
+
+- [ ] **Step 4: Commit macro migration**
+
+Run:
+
+```sh
+git add src/gpu/metal/mod.rs
+git commit -F /private/tmp/diffusionx-commit.txt
+```
+
+Use this message:
+
+```text
+refactor(gpu): port Metal moment dispatch to objc2
+
+Summary:
+- replace Metal device, queue, library, pipeline, buffer, and encoder calls with objc2-metal helpers
+- keep moment macro signatures and generated GPU estimator behavior unchanged
+
+Rationale:
+- move Objective-C ownership and unsafe encoder binding into one private adapter layer
+- preserve the public metal feature API while replacing the deprecated binding crate
+
+Tests:
+- cargo check --features metal --no-default-features: expected remaining random/backend type errors before random port
+
+Co-authored-by: Codex <noreply@openai.com>
+```
+
+## Task 5: Port Metal Random Functions
+
+**Files:**
+- Modify: `src/gpu/metal/random.rs`
+
+- [ ] **Step 1: Replace imports and static types**
+
+At the top of `src/gpu/metal/random.rs`, use:
+
+```rust
+use crate::{
+    XError, XResult,
+    gpu::metal::{
+        MetalLibrary, MetalPipeline, RANDOM_METALLIB, finish_command_buffer, get_pipeline,
+        load_library, new_shared_buffer, read_buffer_vec_f32, set_buffer, set_scalar,
+        thread_config,
+    },
+};
+use objc2::rc::Retained;
+use rand::RngExt;
+use std::sync::LazyLock;
+
+static LIBRARY: LazyLock<XResult<Retained<MetalLibrary>>> =
+    LazyLock::new(|| load_library(RANDOM_METALLIB));
+static STANDARD_STABLE_PIPELINE: LazyLock<XResult<Retained<MetalPipeline>>> =
+    LazyLock::new(|| {
+        let library = LIBRARY.as_ref()?;
+        get_pipeline(library, "standard_stable_rand")
+    });
+static UNIFORM_PIPELINE: LazyLock<XResult<Retained<MetalPipeline>>> = LazyLock::new(|| {
+    let library = LIBRARY.as_ref()?;
+    get_pipeline(library, "randuniform")
+});
+static NORMAL_PIPELINE: LazyLock<XResult<Retained<MetalPipeline>>> = LazyLock::new(|| {
+    let library = LIBRARY.as_ref()?;
+    get_pipeline(library, "randnormal")
+});
+static EXP_PIPELINE: LazyLock<XResult<Retained<MetalPipeline>>> = LazyLock::new(|| {
+    let library = LIBRARY.as_ref()?;
+    get_pipeline(library, "randexp")
+});
+```
+
+Make `MetalLibrary` and `MetalPipeline` aliases `pub(crate)` in `mod.rs`.
+
+- [ ] **Step 2: Add shared kernel launch helper**
+
+Add below the static pipelines:
+
+```rust
+fn command_encoder(
+    pipeline: &MetalPipeline,
+) -> XResult<(
+    Retained<crate::gpu::metal::MetalCommandBuffer>,
+    Retained<crate::gpu::metal::MetalComputeEncoder>,
+)> {
+    let queue = crate::gpu::metal::METAL_QUEUE.as_ref()?;
+    let command_buffer = queue
+        .commandBuffer()
+        .ok_or_else(|| XError::Other("Failed to create Metal command buffer".into()))?;
+    let encoder = command_buffer
+        .computeCommandEncoder()
+        .ok_or_else(|| XError::Other("Failed to create Metal compute encoder".into()))?;
+    encoder.setComputePipelineState(pipeline);
+    Ok((command_buffer, encoder))
+}
+```
+
+Make `MetalCommandBuffer` and `MetalComputeEncoder` aliases `pub(crate)` in `mod.rs`.
+
+- [ ] **Step 3: Port `standard_stable_rands` body**
+
+Replace only the Metal object setup, binding, dispatch, and readback with:
+
+```rust
+let pipeline = STANDARD_STABLE_PIPELINE.as_ref()?;
+
+let (inv_alpha, one_minus_alpha_div_alpha, b, s) = if (alpha - 1.0).abs() < 1e-3 {
+    (0.0f32, 0.0f32, 0.0f32, 0.0f32)
+} else {
+    let inv_alpha = 1.0 / alpha;
+    let one_minus_alpha_div_alpha = (1.0 - alpha) * inv_alpha;
+    let tmp = beta * (alpha * std::f32::consts::FRAC_PI_2).tan();
+    let b = tmp.atan() * inv_alpha;
+    let s = (1.0 + tmp * tmp).powf(0.5 * inv_alpha);
+    (inv_alpha, one_minus_alpha_div_alpha, b, s)
+};
+
+let out_buffer = new_shared_buffer(len * std::mem::size_of::<f32>())?;
+let seed: u64 = rand::rng().random();
+let len_u32 = len as u32;
+let (thread_groups, threads_per_group) = thread_config(len);
+let (command_buffer, encoder) = command_encoder(pipeline)?;
+
+set_buffer(&encoder, 0, &out_buffer);
+set_scalar(&encoder, 1, &alpha);
+set_scalar(&encoder, 2, &beta);
+set_scalar(&encoder, 3, &inv_alpha);
+set_scalar(&encoder, 4, &one_minus_alpha_div_alpha);
+set_scalar(&encoder, 5, &b);
+set_scalar(&encoder, 6, &s);
+set_scalar(&encoder, 7, &len_u32);
+set_scalar(&encoder, 8, &seed);
+
+encoder.dispatchThreadgroups_threadsPerThreadgroup(thread_groups, threads_per_group);
+encoder.endEncoding();
+finish_command_buffer(&command_buffer)?;
+
+Ok(read_buffer_vec_f32(&out_buffer, len))
+```
+
+- [ ] **Step 4: Port `metalrands` body**
+
+Use:
+
+```rust
+let pipeline = UNIFORM_PIPELINE.as_ref()?;
+let out_buffer = new_shared_buffer(n * std::mem::size_of::<f32>())?;
+let seed: u64 = rand::rng().random();
+let len_u32 = n as u32;
+let (thread_groups, threads_per_group) = thread_config(n);
+let (command_buffer, encoder) = command_encoder(pipeline)?;
+
+set_buffer(&encoder, 0, &out_buffer);
+set_scalar(&encoder, 1, &len_u32);
+set_scalar(&encoder, 2, &seed);
+
+encoder.dispatchThreadgroups_threadsPerThreadgroup(thread_groups, threads_per_group);
+encoder.endEncoding();
+finish_command_buffer(&command_buffer)?;
+
+Ok(read_buffer_vec_f32(&out_buffer, n))
+```
+
+- [ ] **Step 5: Port `metalrandn` body**
+
+Use:
+
+```rust
+let pipeline = NORMAL_PIPELINE.as_ref()?;
+let out_buffer = new_shared_buffer(n * std::mem::size_of::<f32>())?;
+let seed: u64 = rand::rng().random();
+let len_u32 = n as u32;
+let (thread_groups, threads_per_group) = thread_config(n);
+let (command_buffer, encoder) = command_encoder(pipeline)?;
+
+set_buffer(&encoder, 0, &out_buffer);
+set_scalar(&encoder, 1, &len_u32);
+set_scalar(&encoder, 2, &mu);
+set_scalar(&encoder, 3, &sigma);
+set_scalar(&encoder, 4, &seed);
+
+encoder.dispatchThreadgroups_threadsPerThreadgroup(thread_groups, threads_per_group);
+encoder.endEncoding();
+finish_command_buffer(&command_buffer)?;
+
+Ok(read_buffer_vec_f32(&out_buffer, n))
+```
+
+- [ ] **Step 6: Port `metalrandexp` body**
+
+Use:
+
+```rust
+let pipeline = EXP_PIPELINE.as_ref()?;
+let out_buffer = new_shared_buffer(n * std::mem::size_of::<f32>())?;
+let seed: u64 = rand::rng().random();
+let len_u32 = n as u32;
+let (thread_groups, threads_per_group) = thread_config(n);
+let (command_buffer, encoder) = command_encoder(pipeline)?;
+
+set_buffer(&encoder, 0, &out_buffer);
+set_scalar(&encoder, 1, &len_u32);
+set_scalar(&encoder, 2, &seed);
+
+encoder.dispatchThreadgroups_threadsPerThreadgroup(thread_groups, threads_per_group);
+encoder.endEncoding();
+finish_command_buffer(&command_buffer)?;
+
+Ok(read_buffer_vec_f32(&out_buffer, n))
+```
+
+- [ ] **Step 7: Compile Metal backend**
+
+Run:
+
+```sh
+cargo check --features metal --no-default-features
+```
+
+Expected: PASS or only process-file concrete type errors. Fix process-file type errors by replacing `metal::Library` with `Retained<MetalLibrary>` imports and leaving public APIs untouched.
+
+- [ ] **Step 8: Commit random migration**
+
+Run:
+
+```sh
+git add src/gpu/metal/random.rs src/gpu/metal/bm.rs src/gpu/metal/ou.rs src/gpu/metal/levy.rs src/gpu/metal/mod.rs
+git commit -F /private/tmp/diffusionx-commit.txt
+```
+
+Use this message:
+
+```text
+refactor(gpu): port Metal random kernels to objc2
+
+Summary:
+- move Metal random kernel dispatch and readback to the objc2-metal adapter helpers
+- preserve existing random function signatures and output semantics
+
+Rationale:
+- complete removal of direct deprecated metal crate usage from the Metal backend
+- keep unsafe buffer binding centralized in the backend adapter
+
+Tests:
+- cargo check --features metal --no-default-features
+
+Co-authored-by: Codex <noreply@openai.com>
+```
+
+## Task 6: Add Metal Smoke Tests
+
+**Files:**
+- Modify: `src/gpu/metal/random.rs`
+
+- [ ] **Step 1: Add random smoke tests**
+
+Append this test module to `src/gpu/metal/random.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metal_uniform_rng_returns_finite_values_in_range() {
+        let values = metalrands(128).unwrap();
+        assert_eq!(values.len(), 128);
+        assert!(values.iter().all(|value| value.is_finite()));
+        assert!(values.iter().all(|value| *value > 0.0 && *value <= 1.0));
+    }
+
+    #[test]
+    fn metal_normal_rng_returns_finite_values() {
+        let values = metalrandn(128, 0.0, 1.0).unwrap();
+        assert_eq!(values.len(), 128);
+        assert!(values.iter().all(|value| value.is_finite()));
+    }
+
+    #[test]
+    fn metal_exp_rng_returns_finite_non_negative_values() {
+        let values = metalrandexp(128).unwrap();
+        assert_eq!(values.len(), 128);
+        assert!(values.iter().all(|value| value.is_finite()));
+        assert!(values.iter().all(|value| *value >= 0.0));
+    }
+
+    #[test]
+    fn metal_standard_stable_rng_returns_finite_values() {
+        let values = standard_stable_rands(1.5, 0.0, 128).unwrap();
+        assert_eq!(values.len(), 128);
+        assert!(values.iter().all(|value| value.is_finite()));
+    }
+}
+```
+
+- [ ] **Step 2: Run targeted Metal random tests**
+
+Run:
+
+```sh
+cargo test --features metal --no-default-features gpu::metal::random
+```
+
+Expected: PASS on a macOS machine with Metal support and Xcode command-line tools.
+
+- [ ] **Step 3: Run existing Metal moment tests**
+
+Run:
+
+```sh
+cargo test --features metal --no-default-features gpu::metal::bm::tests::test_gpu_moment
+cargo test --features metal --no-default-features gpu::metal::ou::tests::test_gpu_moment
+```
+
+Expected: PASS. If Lévy has no explicit test, do not add a broad stochastic accuracy test in this migration; keep the new coverage focused on porting the binding layer.
+
+- [ ] **Step 4: Commit smoke tests**
+
+Run:
+
+```sh
+git add src/gpu/metal/random.rs
+git commit -F /private/tmp/diffusionx-commit.txt
+```
+
+Use this message:
+
+```text
+test(gpu): add Metal random smoke coverage
+
+Summary:
+- add Metal random backend smoke tests for length, finite values, and basic ranges
+
+Rationale:
+- verify objc2-metal readback behavior for vector-producing kernels
+- keep stochastic assertions broad enough to avoid brittle random-output failures
+
+Tests:
+- cargo test --features metal --no-default-features gpu::metal::random
+- cargo test --features metal --no-default-features gpu::metal::bm::tests::test_gpu_moment
+- cargo test --features metal --no-default-features gpu::metal::ou::tests::test_gpu_moment
+
+Co-authored-by: Codex <noreply@openai.com>
+```
+
+## Task 7: Full Verification and Cleanup
+
+**Files:**
+- Inspect: all modified files
+- Optional Modify: `README.md`
+
+- [ ] **Step 1: Search for deprecated crate usage**
+
+Run:
+
+```sh
+rg -n 'use metal|metal::|MTLResourceOptions|new_buffer|new_command_buffer|new_compute_command_encoder|dispatch_thread_groups|set_bytes|set_buffer' src/gpu/metal Cargo.toml
+```
+
+Expected: no old `metal::` crate references. `MTLResourceOptions` may appear only from `objc2_metal`.
+
+- [ ] **Step 2: Run non-Metal verification**
+
+Run:
+
+```sh
+cargo check --all
+cargo test --lib
+```
+
+Expected: PASS. These commands protect default users who do not enable Metal.
+
+- [ ] **Step 3: Run Metal verification**
+
+Run:
+
+```sh
+cargo check --features metal --no-default-features
+cargo test --features metal --no-default-features gpu::metal
+```
+
+Expected: PASS on a Metal-capable macOS system with Xcode command-line tools.
+
+- [ ] **Step 4: Run formatting and linting**
+
+Run:
+
+```sh
+cargo fmt -- --check
+cargo clippy --all-targets --tests --benches -- -D warnings
+cargo clippy --all-targets --features metal --no-default-features --tests --benches -- -D warnings
+```
+
+Expected: PASS. If Metal clippy cannot run because the machine lacks Metal compiler tools, record the exact error in the final response and ensure non-Metal clippy passes.
+
+- [ ] **Step 5: Decide whether README changed**
+
+Run:
+
+```sh
+git diff -- README.md
+```
+
+Expected: no README diff. If dependency migration changed user-facing setup instructions, add a short README note under GPU Acceleration that Metal builds use `objc2-metal` internally but still enable `features = ["metal"]`.
+
+- [ ] **Step 6: Final commit for cleanup if needed**
+
+If formatting, README, or small follow-up cleanup changed files after prior commits, commit only those changes:
+
+```text
+chore(gpu): finish Metal objc2 migration cleanup
+
+Summary:
+- apply final formatting and documentation cleanup for the Metal objc2 migration
+
+Rationale:
+- keep the migration branch clean after full verification
+
+Tests:
+- cargo check --all
+- cargo test --lib
+- cargo check --features metal --no-default-features
+- cargo test --features metal --no-default-features gpu::metal
+- cargo fmt -- --check
+- cargo clippy --all-targets --tests --benches -- -D warnings
+- cargo clippy --all-targets --features metal --no-default-features --tests --benches -- -D warnings
+
+Co-authored-by: Codex <noreply@openai.com>
+```
+
+Do not create an empty cleanup commit if there are no changes.
+
+## Self-Review
+
+- Spec coverage: The plan preserves the `metal` feature and public API, replaces the deprecated binding dependency, keeps `build.rs` and kernels unchanged by default, centralizes Objective-C ownership and unsafe calls, adds command-buffer error checks, and includes Metal/non-Metal verification.
+- Placeholder scan: No unresolved placeholder markers or open-ended test-writing steps remain; every code-changing task includes concrete snippets and commands.
+- Type consistency: Helper names introduced in Task 3 are reused in Task 4 and Task 5. Public APIs named in the spec remain unchanged.

--- a/docs/superpowers/specs/2026-05-21-metal-objc2-migration-design.md
+++ b/docs/superpowers/specs/2026-05-21-metal-objc2-migration-design.md
@@ -1,0 +1,256 @@
+# Metal Binding Migration Design
+
+## Context
+
+The crate currently exposes optional GPU acceleration through the `metal` feature and
+the `diffusionx::gpu::metal` module. The public API should not change. Users should
+continue enabling `features = ["metal"]` and calling the existing `GPUMoment` methods
+or `gpu::metal::random::*` functions.
+
+The current backend uses the `metal` crate. That crate is deprecated because the old
+`objc` ecosystem is unmaintained, and its documentation recommends new development
+use `objc2` and `objc2-metal` instead:
+<https://docs.rs/metal/latest/src/metal/lib.rs.html#70-79>.
+
+The replacement crate exposes the Metal Objective-C protocols directly. For example,
+`MTLCreateSystemDefaultDevice()` returns a retained Objective-C protocol object, and
+the main methods are named after their Objective-C selectors:
+
+- `MTLCreateSystemDefaultDevice`: <https://docs.rs/objc2-metal/latest/objc2_metal/fn.MTLCreateSystemDefaultDevice.html>
+- `MTLDevice`: <https://docs.rs/objc2-metal/latest/objc2_metal/trait.MTLDevice.html>
+- `MTLCommandQueue`: <https://docs.rs/objc2-metal/latest/objc2_metal/trait.MTLCommandQueue.html>
+- `MTLComputeCommandEncoder`: <https://docs.rs/objc2-metal/latest/objc2_metal/trait.MTLComputeCommandEncoder.html>
+
+## Goals
+
+- Replace the unmaintained `metal` crate with `objc2-metal` for the Metal backend.
+- Preserve the existing public API, feature name, module paths, and behavior.
+- Keep `build.rs` Metal shader compilation unchanged unless migration reveals a direct
+  compatibility issue.
+- Centralize Objective-C ownership and `unsafe` calls in small private helpers.
+- Improve command-buffer error reporting where `objc2-metal` exposes useful status.
+
+## Non-Goals
+
+- Do not rename the Cargo feature from `metal`.
+- Do not change `diffusionx::gpu::metal` public functions or `GPUMoment`.
+- Do not rewrite Metal kernels.
+- Do not redesign the CUDA backend.
+- Do not introduce a cross-backend GPU abstraction as part of this migration.
+
+## Dependency Plan
+
+`Cargo.toml` should keep:
+
+```toml
+[features]
+metal = ["dep:objc2-metal"]
+```
+
+The implementation may also need a direct `objc2` and/or `objc2-foundation`
+dependency if the types are not conveniently re-exported by `objc2-metal`.
+These dependencies must remain optional and enabled only by the `metal` feature.
+
+The old dependency:
+
+```toml
+metal = { version = "0.33", optional = true }
+```
+
+should be removed once the backend no longer imports it.
+
+## Migration Boundary
+
+The migration is limited to the `#[cfg(feature = "metal")]` backend:
+
+- `src/gpu/metal/mod.rs`
+- `src/gpu/metal/random.rs`
+- Type references in `src/gpu/metal/{bm,ou,levy}.rs`
+- `Cargo.toml` and `Cargo.lock`
+
+The following should remain behaviorally unchanged:
+
+- `src/gpu/mod.rs`
+- `src/simulation/prelude.rs`
+- `build.rs` Metal branch
+- `kernels/metal-kernel/*.metal`
+- README examples and benchmark call sites
+
+## Internal Adapter Design
+
+`src/gpu/metal/mod.rs` should own a private adapter layer around `objc2-metal`.
+The rest of the Metal backend should not need to manipulate Objective-C ownership
+or raw pointers directly.
+
+Suggested private type aliases:
+
+```rust
+type MetalDevice = objc2::runtime::ProtocolObject<dyn objc2_metal::MTLDevice>;
+type MetalQueue = objc2::runtime::ProtocolObject<dyn objc2_metal::MTLCommandQueue>;
+type MetalLibrary = objc2::runtime::ProtocolObject<dyn objc2_metal::MTLLibrary>;
+type MetalPipeline = objc2::runtime::ProtocolObject<dyn objc2_metal::MTLComputePipelineState>;
+type MetalBuffer = objc2::runtime::ProtocolObject<dyn objc2_metal::MTLBuffer>;
+```
+
+The exact aliases may be adjusted during implementation to match the crate's latest
+type paths, but the adapter should store retained Objective-C objects, not borrowed
+objects with unclear lifetimes.
+
+Core helpers:
+
+- `METAL_DEVICE: LazyLock<XResult<Retained<MetalDevice>>>`
+  - Uses `MTLCreateSystemDefaultDevice()`.
+  - Returns `XError::Other("No Metal device found")` if unavailable.
+- `METAL_QUEUE: LazyLock<XResult<Retained<MetalQueue>>>`
+  - Uses `device.newCommandQueue()`.
+  - Converts a `None` return into `XError::Other`.
+- `load_library(path: &str) -> XResult<Retained<MetalLibrary>>`
+  - Converts `path` through `NSString::from_str`.
+  - Uses `device.newLibraryWithFile_error(...)`.
+  - Includes the path and `NSError` description in failures.
+- `get_pipeline(library, function_name) -> XResult<Retained<MetalPipeline>>`
+  - Converts `function_name` through `NSString::from_str`.
+  - Uses `library.newFunctionWithName(...)`.
+  - Uses `device.newComputePipelineStateWithFunction_error(...)`.
+  - Includes the kernel name and `NSError` description in failures.
+- `thread_config(particles: usize) -> (MTLSize, MTLSize)`
+  - Keeps the current 256-thread group size and `particles.div_ceil(256)`.
+
+Buffer and encoder helpers:
+
+- `new_shared_buffer(bytes: usize) -> XResult<Retained<MetalBuffer>>`
+  - Uses `MTLResourceOptions::StorageModeShared`.
+  - Treats `None` as allocation failure.
+- `zero_buffer_f32(buffer)` and `read_buffer_f32(buffer)`
+  - Use `MTLBuffer::contents()` and pointer casts in one place.
+- `read_buffer_vec_f32(buffer, len)`
+  - Reads a completed shared buffer into `Vec<f32>`.
+- `set_buffer(encoder, index, buffer)`
+  - Wraps unsafe `setBuffer_offset_atIndex`.
+- `set_scalar<T>(encoder, index, &value)`
+  - Wraps unsafe `setBytes_length_atIndex`.
+- `finish_command_buffer(command_buffer)`
+  - Calls `commit()` and `waitUntilCompleted()`.
+  - Checks `command_buffer.error()` after completion and maps it to `XError::Other`.
+
+## Data Flow
+
+Moment kernels keep the existing execution flow:
+
+1. Lazily load the `.metallib` path injected by `build.rs`.
+2. Lazily create one pipeline per kernel function.
+3. Allocate one shared `f32` output buffer.
+4. Zero-initialize the output buffer.
+5. Generate a host seed with `rand`.
+6. Create a command buffer and compute encoder.
+7. Bind output buffer at index 0.
+8. Bind scalar kernel parameters with `set_scalar`.
+9. Bind `particles_u32` and seed.
+10. Bind threadgroup memory for moment reductions.
+11. Dispatch thread groups.
+12. End encoding, wait for completion, check command-buffer error.
+13. Read the output sum and return `sum / particles as f32`.
+
+Central moment kernels keep their two-pass flow: compute mean first, then run the
+central moment kernel using that mean.
+
+Random kernels keep the existing execution flow:
+
+1. Allocate one shared output buffer sized for `len` or `n` `f32` values.
+2. Bind output buffer at index 0.
+3. Bind scalar distribution parameters, length, and seed.
+4. Dispatch and wait.
+5. Read a `Vec<f32>` of the requested length.
+
+## Error Handling
+
+Public fallible APIs continue returning `XResult<T>`.
+
+New or preserved error cases should include:
+
+- No system Metal device.
+- Command queue creation failed.
+- Library path could not be loaded.
+- Kernel function not found in library.
+- Compute pipeline creation failed.
+- Buffer allocation failed.
+- Command buffer creation failed.
+- Compute encoder creation failed.
+- Command buffer completed with an error.
+
+Errors from Objective-C APIs should include the operation name and, when practical,
+the `NSError` localized description.
+
+## Safety Rules
+
+All `unsafe` calls introduced by `objc2-metal` should stay inside private helpers
+or tiny local blocks in `src/gpu/metal/mod.rs`.
+
+Each unsafe block should be justified by a short comment covering:
+
+- The pointer comes from a live stack value or retained Metal buffer.
+- The value length matches the Metal kernel argument type.
+- Bound buffers remain alive until `waitUntilCompleted()` returns.
+- Shared-buffer reads happen only after command-buffer completion.
+
+The process-specific modules should not contain raw Objective-C message calls or
+manual `NonNull<c_void>` construction unless a later implementation proves a helper
+would obscure correctness.
+
+## Testing and Verification
+
+Start with non-Metal checks to ensure the optional dependency change did not affect
+default users:
+
+```sh
+cargo check --all
+cargo test --lib
+```
+
+Then verify the Metal feature on macOS with the Apple Metal toolchain:
+
+```sh
+cargo check --features metal --no-default-features
+cargo test --features metal --no-default-features gpu::metal
+```
+
+Run formatting and linting before completion:
+
+```sh
+cargo fmt -- --check
+cargo clippy --all-targets --tests --benches -- -D warnings
+```
+
+If Metal-specific clippy is supported in the local environment, run:
+
+```sh
+cargo clippy --all-targets --features metal --no-default-features --tests --benches -- -D warnings
+```
+
+Expected behavior checks:
+
+- Existing BM and OU Metal moment tests pass.
+- Metal random functions return the requested number of values.
+- Uniform RNG values remain in the expected range.
+- Normal, exponential, and stable RNG outputs are finite for small deterministic
+  smoke-test sizes.
+- README GPU examples and Metal benchmark call sites still compile without API edits.
+
+## Implementation Sequence
+
+1. Replace optional dependency metadata in `Cargo.toml`.
+2. Introduce private objc2-metal type aliases and helpers in `src/gpu/metal/mod.rs`.
+3. Port `METAL_DEVICE`, `METAL_QUEUE`, `load_library`, `get_pipeline`, and
+   `thread_config`.
+4. Port the two Metal moment macros to call the new helpers.
+5. Port `src/gpu/metal/random.rs` to the new helpers.
+6. Adjust `bm.rs`, `ou.rs`, and `levy.rs` only where concrete `metal::...` type
+   names need replacement.
+7. Run narrow Metal build checks, then non-Metal checks, then formatting and linting.
+8. Update docs only if the public behavior or setup requirements changed.
+
+## Open Decisions
+
+No product/API decisions are open. During implementation, exact dependency feature
+flags should be selected by the compiler errors and the `objc2-metal` feature list,
+but they must remain optional and gated behind the existing `metal` feature.

--- a/src/gpu/cuda/random.rs
+++ b/src/gpu/cuda/random.rs
@@ -76,7 +76,7 @@ pub fn standard_stable_rands(alpha: f32, beta: f32, len: usize) -> XResult<Vec<f
 }
 
 /// Generate standard uniform random numbers on the CUDA GPU.
-pub fn curands(n: usize) -> XResult<Vec<f32>> {
+pub fn rand(n: usize) -> XResult<Vec<f32>> {
     let stream = CUDA_STREAM.as_ref()?;
     let rng = CudaRng::new(rand::rng().random(), stream.clone())?;
     let mut out_device = stream.alloc_zeros::<f32>(n)?;
@@ -86,7 +86,7 @@ pub fn curands(n: usize) -> XResult<Vec<f32>> {
 }
 
 /// Generate normal random numbers on the CUDA GPU.
-pub fn curandn(n: usize, mu: f32, sigma: f32) -> XResult<Vec<f32>> {
+pub fn randn(n: usize, mu: f32, sigma: f32) -> XResult<Vec<f32>> {
     let stream = CUDA_STREAM.as_ref()?;
     let rng = CudaRng::new(rand::rng().random(), stream.clone())?;
     let mut out_device = stream.alloc_zeros::<f32>(n)?;
@@ -98,6 +98,6 @@ pub fn curandn(n: usize, mu: f32, sigma: f32) -> XResult<Vec<f32>> {
 generate_cuda_rng!(curandexp_impl, EXP_RNG,);
 
 /// Generate standard exponential random numbers on the CUDA GPU.
-pub fn curandexp(n: usize) -> XResult<Vec<f32>> {
+pub fn randexp(n: usize) -> XResult<Vec<f32>> {
     curandexp_impl(n)
 }

--- a/src/gpu/metal/bm.rs
+++ b/src/gpu/metal/bm.rs
@@ -2,13 +2,15 @@ use crate::{
     FloatExt, XResult,
     gpu::{
         GPUMoment,
-        metal::{BM_METALLIB, load_library},
+        metal::{BM_METALLIB, MetalLibrary, load_library},
     },
     simulation::continuous::Bm,
 };
+use objc2::rc::Retained;
 use std::sync::LazyLock;
 
-static LIBRARY: LazyLock<XResult<metal::Library>> = LazyLock::new(|| load_library(BM_METALLIB));
+static LIBRARY: LazyLock<XResult<Retained<MetalLibrary>>> =
+    LazyLock::new(|| load_library(BM_METALLIB));
 
 subscribe_metal_gpu_function!(LIBRARY, mean, "mean", (start_position: f32, diffusivity: f32, duration: f32, time_step: f32));
 
@@ -20,7 +22,19 @@ subscribe_metal_gpu_function!(LIBRARY, frac_raw_moment, "frac_raw_moment", (star
 
 subscribe_metal_central_moment_gpu_function!(LIBRARY, central_moment, "central_moment", (start_position: f32, diffusivity: f32, duration: f32, time_step: f32), i32);
 
-subscribe_metal_central_moment_gpu_function!(LIBRARY, frac_central_moment, "frac_central_moment", (start_position: f32, diffusivity: f32, duration: f32, time_step: f32), f32);
+subscribe_metal_frac_central_moment_gpu_function!(
+    LIBRARY,
+    frac_central_moment,
+    "frac_central_moment",
+    (
+        start_position: f32,
+        diffusivity: f32,
+        duration: f32,
+        time_step: f32
+    ),
+    before_order = (),
+    after_order = (start_position, diffusivity, duration, time_step)
+);
 
 impl<T: FloatExt> GPUMoment for Bm<T> {
     fn central_moment_gpu(

--- a/src/gpu/metal/levy.rs
+++ b/src/gpu/metal/levy.rs
@@ -196,3 +196,25 @@ impl<T: FloatExt> GPUMoment for Levy<T> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::gpu::GPUMoment;
+    use crate::simulation::continuous::Levy;
+
+    #[test]
+    fn test_gpu_moment() {
+        // A non-Gaussian alpha so the Levy metallib kernels are dispatched
+        // instead of routing through the Brownian-motion fallback.
+        let levy = Levy::<f32>::new(0.0, 1.5).unwrap();
+
+        let mean = levy.mean_gpu(1.0, 100, 0.1).unwrap();
+        assert!(mean.is_finite());
+
+        let frac_raw = levy.frac_raw_moment_gpu(1.0, 1.2, 100, 0.1).unwrap();
+        assert!(frac_raw.is_finite());
+
+        let frac_central = levy.frac_central_moment_gpu(1.0, 1.2, 100, 0.1).unwrap();
+        assert!(frac_central.is_finite());
+    }
+}

--- a/src/gpu/metal/levy.rs
+++ b/src/gpu/metal/levy.rs
@@ -2,13 +2,15 @@ use crate::{
     FloatExt, XError, XResult,
     gpu::{
         GPUMoment,
-        metal::{LEVY_METALLIB, load_library},
+        metal::{LEVY_METALLIB, MetalLibrary, load_library},
     },
     simulation::continuous::{Bm, Levy},
 };
+use objc2::rc::Retained;
 use std::sync::LazyLock;
 
-static LIBRARY: LazyLock<XResult<metal::Library>> = LazyLock::new(|| load_library(LEVY_METALLIB));
+static LIBRARY: LazyLock<XResult<Retained<MetalLibrary>>> =
+    LazyLock::new(|| load_library(LEVY_METALLIB));
 
 subscribe_metal_gpu_function!(LIBRARY, mean, "mean", (alpha: f32, start_position: f32, duration: f32, time_step: f32, inv_alpha: f32, one_minus_alpha_div_alpha: f32));
 
@@ -16,7 +18,26 @@ subscribe_metal_gpu_function!(LIBRARY, raw_moment, "raw_moment", (alpha: f32, st
 
 subscribe_metal_gpu_function!(LIBRARY, frac_raw_moment, "frac_raw_moment", (alpha: f32, start_position: f32, order: f32, duration: f32, time_step: f32, inv_alpha: f32, one_minus_alpha_div_alpha: f32));
 
-subscribe_metal_central_moment_gpu_function!(LIBRARY, frac_central_moment, "frac_central_moment", (alpha: f32, start_position: f32, duration: f32, time_step: f32, inv_alpha: f32, one_minus_alpha_div_alpha: f32), f32);
+subscribe_metal_frac_central_moment_gpu_function!(
+    LIBRARY,
+    frac_central_moment,
+    "frac_central_moment",
+    (
+        alpha: f32,
+        start_position: f32,
+        duration: f32,
+        time_step: f32,
+        inv_alpha: f32,
+        one_minus_alpha_div_alpha: f32
+    ),
+    before_order = (alpha, start_position),
+    after_order = (
+        duration,
+        time_step,
+        inv_alpha,
+        one_minus_alpha_div_alpha
+    )
+);
 
 impl<T: FloatExt> GPUMoment for Levy<T> {
     fn central_moment_gpu(

--- a/src/gpu/metal/mod.rs
+++ b/src/gpu/metal/mod.rs
@@ -1,6 +1,7 @@
 use crate::{XError, XResult};
+use dispatch2::DispatchData;
 use objc2::{rc::Retained, runtime::ProtocolObject};
-use objc2_foundation::{NSString, NSURL};
+use objc2_foundation::NSString;
 use objc2_metal::{
     MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder, MTLCommandQueue,
     MTLComputeCommandEncoder, MTLComputePipelineState, MTLCreateSystemDefaultDevice, MTLDevice,
@@ -34,20 +35,23 @@ pub(crate) static METAL_QUEUE: LazyLock<XResult<Retained<MetalQueue>>> = LazyLoc
         .ok_or_else(|| XError::Other("Failed to create Metal command queue".into()))
 });
 
-// Pre-compiled Metal library paths (set by build.rs)
-pub(crate) const BM_METALLIB: &str = env!("BM_KERNEL_METALLIB");
-pub(crate) const LEVY_METALLIB: &str = env!("LEVY_KERNEL_METALLIB");
-pub(crate) const OU_METALLIB: &str = env!("OU_KERNEL_METALLIB");
-pub(crate) const RANDOM_METALLIB: &str = env!("RANDOM_KERNEL_METALLIB");
+// Pre-compiled Metal libraries, embedded into the binary at build time.
+// build.rs compiles each `.metal` source to a `.metallib` and exports its path;
+// `include_bytes!` then bakes the bytes in, so the binary is self-contained and
+// does not depend on the build directory existing at runtime.
+pub(crate) const BM_METALLIB: &[u8] = include_bytes!(env!("BM_KERNEL_METALLIB"));
+pub(crate) const LEVY_METALLIB: &[u8] = include_bytes!(env!("LEVY_KERNEL_METALLIB"));
+pub(crate) const OU_METALLIB: &[u8] = include_bytes!(env!("OU_KERNEL_METALLIB"));
+pub(crate) const RANDOM_METALLIB: &[u8] = include_bytes!(env!("RANDOM_KERNEL_METALLIB"));
 
-/// Load a pre-compiled Metal library from path
-pub(crate) fn load_library(path: &str) -> XResult<Retained<MetalLibrary>> {
+/// Load a pre-compiled Metal library from bytes embedded in the binary.
+pub(crate) fn load_library(metallib: &'static [u8]) -> XResult<Retained<MetalLibrary>> {
     let device = METAL_DEVICE.as_ref().map_err(Clone::clone)?;
-    let url = NSURL::fileURLWithPath(&NSString::from_str(path));
+    let data = DispatchData::from_static_bytes(metallib);
 
     device
-        .newLibraryWithURL_error(&url)
-        .map_err(|e| XError::Other(format!("Failed to load metallib '{}': {}", path, e)))
+        .newLibraryWithData_error(&data)
+        .map_err(|e| XError::Other(format!("Failed to load embedded metallib: {e}")))
 }
 
 /// Get compute pipeline state for a kernel function

--- a/src/gpu/metal/mod.rs
+++ b/src/gpu/metal/mod.rs
@@ -1,14 +1,34 @@
-use crate::XResult;
-use metal::{Device, MTLSize};
-use std::sync::LazyLock;
+use crate::{XError, XResult};
+use objc2::{rc::Retained, runtime::ProtocolObject};
+use objc2_foundation::NSString;
+use objc2_metal::{
+    MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder, MTLCommandQueue,
+    MTLComputeCommandEncoder, MTLComputePipelineState, MTLCreateSystemDefaultDevice, MTLDevice,
+    MTLFunction, MTLLibrary, MTLResourceOptions, MTLSize,
+};
+use std::{ffi::c_void, ptr::NonNull, sync::LazyLock};
 
-pub(crate) static METAL_DEVICE: LazyLock<XResult<Device>> = LazyLock::new(|| {
-    Device::system_default().ok_or_else(|| crate::XError::Other("No Metal device found".into()))
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {}
+
+pub(crate) type MetalDevice = ProtocolObject<dyn MTLDevice>;
+pub(crate) type MetalQueue = ProtocolObject<dyn MTLCommandQueue>;
+pub(crate) type MetalLibrary = ProtocolObject<dyn MTLLibrary>;
+pub(crate) type MetalFunction = ProtocolObject<dyn MTLFunction>;
+pub(crate) type MetalPipeline = ProtocolObject<dyn MTLComputePipelineState>;
+pub(crate) type MetalBuffer = ProtocolObject<dyn MTLBuffer>;
+pub(crate) type MetalCommandBuffer = ProtocolObject<dyn MTLCommandBuffer>;
+pub(crate) type MetalComputeEncoder = ProtocolObject<dyn MTLComputeCommandEncoder>;
+
+pub(crate) static METAL_DEVICE: LazyLock<XResult<Retained<MetalDevice>>> = LazyLock::new(|| {
+    MTLCreateSystemDefaultDevice().ok_or_else(|| XError::Other("No Metal device found".into()))
 });
 
-pub(crate) static METAL_QUEUE: LazyLock<XResult<metal::CommandQueue>> = LazyLock::new(|| {
-    let device = METAL_DEVICE.as_ref()?;
-    Ok(device.new_command_queue())
+pub(crate) static METAL_QUEUE: LazyLock<XResult<Retained<MetalQueue>>> = LazyLock::new(|| {
+    let device = METAL_DEVICE.as_ref().map_err(Clone::clone)?;
+    device
+        .newCommandQueue()
+        .ok_or_else(|| XError::Other("Failed to create Metal command queue".into()))
 });
 
 // Pre-compiled Metal library paths (set by build.rs)
@@ -18,26 +38,131 @@ pub(crate) const OU_METALLIB: &str = env!("OU_KERNEL_METALLIB");
 pub(crate) const RANDOM_METALLIB: &str = env!("RANDOM_KERNEL_METALLIB");
 
 /// Load a pre-compiled Metal library from path
-pub(crate) fn load_library(path: &str) -> XResult<metal::Library> {
-    let device = METAL_DEVICE.as_ref()?;
+#[allow(deprecated)]
+pub(crate) fn load_library(path: &str) -> XResult<Retained<MetalLibrary>> {
+    let device = METAL_DEVICE.as_ref().map_err(Clone::clone)?;
+    let filepath = NSString::from_str(path);
+
     device
-        .new_library_with_file(path)
-        .map_err(|e| crate::XError::Other(format!("Failed to load metallib '{}': {}", path, e)))
+        .newLibraryWithFile_error(&filepath)
+        .map_err(|e| XError::Other(format!("Failed to load metallib '{}': {}", path, e)))
 }
 
 /// Get compute pipeline state for a kernel function
 pub(crate) fn get_pipeline(
-    library: &metal::Library,
+    library: &MetalLibrary,
     function_name: &str,
-) -> XResult<metal::ComputePipelineState> {
-    let device = METAL_DEVICE.as_ref()?;
-    let function = library.get_function(function_name, None).map_err(|e| {
-        crate::XError::Other(format!("Function '{}' not found: {}", function_name, e))
-    })?;
+) -> XResult<Retained<MetalPipeline>> {
+    let device = METAL_DEVICE.as_ref().map_err(Clone::clone)?;
+    let function_name_ns = NSString::from_str(function_name);
+    let function: Retained<MetalFunction> = library
+        .newFunctionWithName(&function_name_ns)
+        .ok_or_else(|| XError::Other(format!("Function '{}' not found", function_name)))?;
 
     device
-        .new_compute_pipeline_state_with_function(&function)
-        .map_err(|e| crate::XError::Other(format!("Pipeline creation error: {}", e)))
+        .newComputePipelineStateWithFunction_error(&function)
+        .map_err(|e| XError::Other(format!("Pipeline creation error: {}", e)))
+}
+
+pub(crate) fn new_shared_buffer(bytes: usize) -> XResult<Retained<MetalBuffer>> {
+    let device = METAL_DEVICE.as_ref().map_err(Clone::clone)?;
+    device
+        .newBufferWithLength_options(bytes, MTLResourceOptions::StorageModeShared)
+        .ok_or_else(|| XError::Other(format!("Failed to allocate Metal buffer ({bytes} bytes)")))
+}
+
+pub(crate) fn zero_buffer_f32(buffer: &MetalBuffer) {
+    // SAFETY: `contents` is valid for a shared buffer allocated by this module, and
+    // the caller passes a buffer with space for at least one `f32`.
+    unsafe {
+        *buffer.contents().as_ptr().cast::<f32>() = 0.0;
+    }
+}
+
+pub(crate) fn read_buffer_f32(buffer: &MetalBuffer) -> f32 {
+    // SAFETY: command completion is checked before reads, and moment buffers hold
+    // at least one `f32` in shared storage.
+    unsafe { *buffer.contents().as_ptr().cast::<f32>() }
+}
+
+pub(crate) fn read_buffer_vec_f32(buffer: &MetalBuffer, len: usize) -> Vec<f32> {
+    // SAFETY: command completion is checked before reads, and callers provide the
+    // number of `f32` values used when the shared buffer was allocated.
+    unsafe { std::slice::from_raw_parts(buffer.contents().as_ptr().cast::<f32>(), len).to_vec() }
+}
+
+pub(crate) fn set_buffer(encoder: &MetalComputeEncoder, index: usize, buffer: &MetalBuffer) {
+    // SAFETY: the buffer is retained by the caller until command completion, offset
+    // is zero, and binding indices match the compiled Metal kernels.
+    unsafe {
+        encoder.setBuffer_offset_atIndex(Some(buffer), 0, index);
+    }
+}
+
+pub(crate) fn set_scalar<T>(encoder: &MetalComputeEncoder, index: usize, value: &T) {
+    let ptr = NonNull::from(value).cast::<c_void>();
+    // SAFETY: `value` is a valid pointer for `size_of::<T>()` bytes; Metal copies
+    // scalar bytes into the encoder immediately for the requested binding index.
+    unsafe {
+        encoder.setBytes_length_atIndex(ptr, std::mem::size_of::<T>(), index);
+    }
+}
+
+pub(crate) fn set_threadgroup_memory_length(
+    encoder: &MetalComputeEncoder,
+    index: usize,
+    bytes: usize,
+) {
+    // SAFETY: the binding index and byte length mirror the existing kernels'
+    // threadgroup scratch contract.
+    unsafe {
+        encoder.setThreadgroupMemoryLength_atIndex(bytes, index);
+    }
+}
+
+pub(crate) fn new_command_buffer(queue: &MetalQueue) -> XResult<Retained<MetalCommandBuffer>> {
+    queue
+        .commandBuffer()
+        .ok_or_else(|| XError::Other("Failed to create Metal command buffer".into()))
+}
+
+pub(crate) fn new_compute_encoder(
+    command_buffer: &MetalCommandBuffer,
+) -> XResult<Retained<MetalComputeEncoder>> {
+    command_buffer
+        .computeCommandEncoder()
+        .ok_or_else(|| XError::Other("Failed to create Metal compute encoder".into()))
+}
+
+pub(crate) fn set_pipeline(encoder: &MetalComputeEncoder, pipeline: &MetalPipeline) {
+    encoder.setComputePipelineState(pipeline);
+}
+
+pub(crate) fn dispatch_threadgroups(
+    encoder: &MetalComputeEncoder,
+    thread_groups: MTLSize,
+    threads_per_group: MTLSize,
+) {
+    encoder.dispatchThreadgroups_threadsPerThreadgroup(thread_groups, threads_per_group);
+}
+
+pub(crate) fn end_encoding(encoder: &MetalComputeEncoder) {
+    encoder.endEncoding();
+}
+
+pub(crate) fn finish_command_buffer(command_buffer: &MetalCommandBuffer) -> XResult<()> {
+    command_buffer.commit();
+    command_buffer.waitUntilCompleted();
+
+    if command_buffer.status() == MTLCommandBufferStatus::Error {
+        let message = command_buffer.error().map_or_else(
+            || "Metal command buffer failed".to_string(),
+            |error| error.localizedDescription().to_string(),
+        );
+        return Err(XError::Other(message));
+    }
+
+    Ok(())
 }
 
 /// Calculate thread group configuration for a given number of particles
@@ -47,8 +172,16 @@ pub(crate) fn thread_config(particles: usize) -> (MTLSize, MTLSize) {
     let thread_groups = particles.div_ceil(thread_group_size);
 
     (
-        MTLSize::new(thread_groups as u64, 1, 1),
-        MTLSize::new(thread_group_size as u64, 1, 1),
+        MTLSize {
+            width: thread_groups,
+            height: 1,
+            depth: 1,
+        },
+        MTLSize {
+            width: thread_group_size,
+            height: 1,
+            depth: 1,
+        },
     )
 }
 
@@ -62,82 +195,56 @@ macro_rules! subscribe_metal_gpu_function {
             )+
             particles: usize,
         ) -> XResult<f32> {
-            use metal::MTLResourceOptions;
-
-            let device = $crate::gpu::metal::METAL_DEVICE.as_ref()?;
-            let queue = $crate::gpu::metal::METAL_QUEUE.as_ref()?;
-            static PIPELINE: std::sync::LazyLock<XResult<metal::ComputePipelineState>> =
+            let queue = $crate::gpu::metal::METAL_QUEUE.as_ref().map_err(Clone::clone)?;
+            static PIPELINE: std::sync::LazyLock<XResult<objc2::rc::Retained<$crate::gpu::metal::MetalPipeline>>> =
                 std::sync::LazyLock::new(|| {
-                    let library = $library.as_ref()?;
+                    let library = $library.as_ref().map_err(Clone::clone)?;
                     $crate::gpu::metal::get_pipeline(library, $kernel_name)
                 });
-            let pipeline = PIPELINE.as_ref()?;
+            let pipeline = PIPELINE.as_ref().map_err(Clone::clone)?;
 
             let (thread_groups, threads_per_group) = $crate::gpu::metal::thread_config(particles);
 
-            // Create output buffer
-            let out_buffer = device.new_buffer(
-                std::mem::size_of::<f32>() as u64,
-                MTLResourceOptions::StorageModeShared,
-            );
-
-            // Zero initialize output
-            unsafe {
-                let ptr = out_buffer.contents() as *mut f32;
-                *ptr = 0.0f32;
-            }
+            let out_buffer =
+                $crate::gpu::metal::new_shared_buffer(std::mem::size_of::<f32>())?;
+            $crate::gpu::metal::zero_buffer_f32(&out_buffer);
 
             let mut rng = rand::rng();
             use rand::RngExt;
             let seed: u64 = rng.random();
             let particles_u32 = particles as u32;
 
-            let command_buffer = queue.new_command_buffer();
-            let encoder = command_buffer.new_compute_command_encoder();
+            let command_buffer = $crate::gpu::metal::new_command_buffer(queue)?;
+            let encoder = $crate::gpu::metal::new_compute_encoder(&command_buffer)?;
 
-            encoder.set_compute_pipeline_state(pipeline);
+            $crate::gpu::metal::set_pipeline(&encoder, pipeline);
 
-            // Set buffers
-            let mut buffer_index = 0u64;
-            encoder.set_buffer(buffer_index, Some(&out_buffer), 0);
+            let mut buffer_index = 0usize;
+            $crate::gpu::metal::set_buffer(&encoder, buffer_index, &out_buffer);
             buffer_index += 1;
 
             $(
-                encoder.set_bytes(
-                    buffer_index,
-                    std::mem::size_of::<$param_type>() as u64,
-                    &$param_name as *const $param_type as *const std::ffi::c_void,
-                );
+                $crate::gpu::metal::set_scalar(&encoder, buffer_index, &$param_name);
                 buffer_index += 1;
             )+
 
-            encoder.set_bytes(
-                buffer_index,
-                std::mem::size_of::<u32>() as u64,
-                &particles_u32 as *const u32 as *const std::ffi::c_void,
-            );
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &particles_u32);
             buffer_index += 1;
 
-            encoder.set_bytes(
-                buffer_index,
-                std::mem::size_of::<u64>() as u64,
-                &seed as *const u64 as *const std::ffi::c_void,
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &seed);
+
+            $crate::gpu::metal::set_threadgroup_memory_length(
+                &encoder,
+                0,
+                32 * std::mem::size_of::<f32>(),
             );
 
-            // Set threadgroup memory for SIMD sums (32 floats)
-            encoder.set_threadgroup_memory_length(0, 32 * std::mem::size_of::<f32>() as u64);
+            $crate::gpu::metal::dispatch_threadgroups(&encoder, thread_groups, threads_per_group);
+            $crate::gpu::metal::end_encoding(&encoder);
 
-            encoder.dispatch_thread_groups(thread_groups, threads_per_group);
-            encoder.end_encoding();
+            $crate::gpu::metal::finish_command_buffer(&command_buffer)?;
 
-            command_buffer.commit();
-            command_buffer.wait_until_completed();
-
-            // Read result
-            let sum = unsafe {
-                let ptr = out_buffer.contents() as *const f32;
-                *ptr
-            };
+            let sum = $crate::gpu::metal::read_buffer_f32(&out_buffer);
 
             Ok(sum / particles as f32)
         }
@@ -155,99 +262,153 @@ macro_rules! subscribe_metal_central_moment_gpu_function {
             order: $order_type,
             particles: usize,
         ) -> XResult<f32> {
-            use metal::MTLResourceOptions;
-
-            let device = $crate::gpu::metal::METAL_DEVICE.as_ref()?;
-            let queue = $crate::gpu::metal::METAL_QUEUE.as_ref()?;
-            static PIPELINE: std::sync::LazyLock<XResult<metal::ComputePipelineState>> =
+            let queue = $crate::gpu::metal::METAL_QUEUE.as_ref().map_err(Clone::clone)?;
+            static PIPELINE: std::sync::LazyLock<XResult<objc2::rc::Retained<$crate::gpu::metal::MetalPipeline>>> =
                 std::sync::LazyLock::new(|| {
-                    let library = $library.as_ref()?;
+                    let library = $library.as_ref().map_err(Clone::clone)?;
                     $crate::gpu::metal::get_pipeline(library, $kernel_name)
                 });
-            let pipeline = PIPELINE.as_ref()?;
+            let pipeline = PIPELINE.as_ref().map_err(Clone::clone)?;
 
             let (thread_groups, threads_per_group) = $crate::gpu::metal::thread_config(particles);
 
             // First compute mean
             let mean_val = mean($($param_name,)+ particles)?;
 
-            // Create output buffer
-            let out_buffer = device.new_buffer(
-                std::mem::size_of::<f32>() as u64,
-                MTLResourceOptions::StorageModeShared,
-            );
-
-            // Zero initialize output
-            unsafe {
-                let ptr = out_buffer.contents() as *mut f32;
-                *ptr = 0.0f32;
-            }
+            let out_buffer =
+                $crate::gpu::metal::new_shared_buffer(std::mem::size_of::<f32>())?;
+            $crate::gpu::metal::zero_buffer_f32(&out_buffer);
 
             let mut rng = rand::rng();
             use rand::RngExt;
             let seed: u64 = rng.random();
             let particles_u32 = particles as u32;
 
-            let command_buffer = queue.new_command_buffer();
-            let encoder = command_buffer.new_compute_command_encoder();
+            let command_buffer = $crate::gpu::metal::new_command_buffer(queue)?;
+            let encoder = $crate::gpu::metal::new_compute_encoder(&command_buffer)?;
 
-            encoder.set_compute_pipeline_state(pipeline);
+            $crate::gpu::metal::set_pipeline(&encoder, pipeline);
 
             // Set buffers - order matches kernel signature: out, order, mean, params..., particles, seed
-            let mut buffer_index = 0u64;
-            encoder.set_buffer(buffer_index, Some(&out_buffer), 0);
+            let mut buffer_index = 0usize;
+            $crate::gpu::metal::set_buffer(&encoder, buffer_index, &out_buffer);
             buffer_index += 1;
 
-            encoder.set_bytes(
-                buffer_index,
-                std::mem::size_of::<$order_type>() as u64,
-                &order as *const $order_type as *const std::ffi::c_void,
-            );
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &order);
             buffer_index += 1;
 
-            encoder.set_bytes(
-                buffer_index,
-                std::mem::size_of::<f32>() as u64,
-                &mean_val as *const f32 as *const std::ffi::c_void,
-            );
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &mean_val);
             buffer_index += 1;
 
             $(
-                encoder.set_bytes(
-                    buffer_index,
-                    std::mem::size_of::<$param_type>() as u64,
-                    &$param_name as *const $param_type as *const std::ffi::c_void,
-                );
+                $crate::gpu::metal::set_scalar(&encoder, buffer_index, &$param_name);
                 buffer_index += 1;
             )+
 
-            encoder.set_bytes(
-                buffer_index,
-                std::mem::size_of::<u32>() as u64,
-                &particles_u32 as *const u32 as *const std::ffi::c_void,
-            );
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &particles_u32);
             buffer_index += 1;
 
-            encoder.set_bytes(
-                buffer_index,
-                std::mem::size_of::<u64>() as u64,
-                &seed as *const u64 as *const std::ffi::c_void,
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &seed);
+
+            $crate::gpu::metal::set_threadgroup_memory_length(
+                &encoder,
+                0,
+                32 * std::mem::size_of::<f32>(),
             );
 
-            // Set threadgroup memory for SIMD sums (32 floats)
-            encoder.set_threadgroup_memory_length(0, 32 * std::mem::size_of::<f32>() as u64);
+            $crate::gpu::metal::dispatch_threadgroups(&encoder, thread_groups, threads_per_group);
+            $crate::gpu::metal::end_encoding(&encoder);
 
-            encoder.dispatch_thread_groups(thread_groups, threads_per_group);
-            encoder.end_encoding();
+            $crate::gpu::metal::finish_command_buffer(&command_buffer)?;
 
-            command_buffer.commit();
-            command_buffer.wait_until_completed();
+            let sum = $crate::gpu::metal::read_buffer_f32(&out_buffer);
 
-            // Read result
-            let sum = unsafe {
-                let ptr = out_buffer.contents() as *const f32;
-                *ptr
-            };
+            Ok(sum / particles as f32)
+        }
+    };
+}
+
+/// Macro to generate Metal GPU-accelerated fractional central moment functions.
+macro_rules! subscribe_metal_frac_central_moment_gpu_function {
+    (
+        $library:expr,
+        $func_name:ident,
+        $kernel_name:expr,
+        ($( $param_name:ident: $param_type:ty ),+ $(,)?),
+        before_order = ($( $before_order:ident ),* $(,)?),
+        after_order = ($( $after_order:ident ),* $(,)?)
+    ) => {
+        #[allow(clippy::too_many_arguments)]
+        fn $func_name(
+            $(
+                $param_name: $param_type,
+            )+
+            order: f32,
+            particles: usize,
+        ) -> XResult<f32> {
+            let queue = $crate::gpu::metal::METAL_QUEUE.as_ref().map_err(Clone::clone)?;
+            static PIPELINE: std::sync::LazyLock<XResult<objc2::rc::Retained<$crate::gpu::metal::MetalPipeline>>> =
+                std::sync::LazyLock::new(|| {
+                    let library = $library.as_ref().map_err(Clone::clone)?;
+                    $crate::gpu::metal::get_pipeline(library, $kernel_name)
+                });
+            let pipeline = PIPELINE.as_ref().map_err(Clone::clone)?;
+
+            let (thread_groups, threads_per_group) = $crate::gpu::metal::thread_config(particles);
+
+            let mean_val = mean($($param_name,)+ particles)?;
+
+            let out_buffer =
+                $crate::gpu::metal::new_shared_buffer(std::mem::size_of::<f32>())?;
+            $crate::gpu::metal::zero_buffer_f32(&out_buffer);
+
+            let mut rng = rand::rng();
+            use rand::RngExt;
+            let seed: u64 = rng.random();
+            let particles_u32 = particles as u32;
+
+            let command_buffer = $crate::gpu::metal::new_command_buffer(queue)?;
+            let encoder = $crate::gpu::metal::new_compute_encoder(&command_buffer)?;
+
+            $crate::gpu::metal::set_pipeline(&encoder, pipeline);
+
+            let mut buffer_index = 0usize;
+            $crate::gpu::metal::set_buffer(&encoder, buffer_index, &out_buffer);
+            buffer_index += 1;
+
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &mean_val);
+            buffer_index += 1;
+
+            $(
+                $crate::gpu::metal::set_scalar(&encoder, buffer_index, &$before_order);
+                buffer_index += 1;
+            )*
+
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &order);
+            buffer_index += 1;
+
+            $(
+                $crate::gpu::metal::set_scalar(&encoder, buffer_index, &$after_order);
+                buffer_index += 1;
+            )*
+
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &particles_u32);
+            buffer_index += 1;
+
+            $crate::gpu::metal::set_scalar(&encoder, buffer_index, &seed);
+
+            $crate::gpu::metal::set_threadgroup_memory_length(
+                &encoder,
+                0,
+                32 * std::mem::size_of::<f32>(),
+            );
+
+            $crate::gpu::metal::dispatch_threadgroups(&encoder, thread_groups, threads_per_group);
+            $crate::gpu::metal::end_encoding(&encoder);
+
+            $crate::gpu::metal::finish_command_buffer(&command_buffer)?;
+
+            let sum = $crate::gpu::metal::read_buffer_f32(&out_buffer);
 
             Ok(sum / particles as f32)
         }

--- a/src/gpu/metal/mod.rs
+++ b/src/gpu/metal/mod.rs
@@ -1,6 +1,6 @@
 use crate::{XError, XResult};
 use objc2::{rc::Retained, runtime::ProtocolObject};
-use objc2_foundation::NSString;
+use objc2_foundation::{NSString, NSURL};
 use objc2_metal::{
     MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder, MTLCommandQueue,
     MTLComputeCommandEncoder, MTLComputePipelineState, MTLCreateSystemDefaultDevice, MTLDevice,
@@ -8,6 +8,9 @@ use objc2_metal::{
 };
 use std::{ffi::c_void, ptr::NonNull, sync::LazyLock};
 
+// `MTLCreateSystemDefaultDevice` returns `nil` unless CoreGraphics is linked into
+// the process. No symbol from CoreGraphics is referenced directly, so force the
+// link with an empty `extern` block; removing it breaks headless device creation.
 #[link(name = "CoreGraphics", kind = "framework")]
 unsafe extern "C" {}
 
@@ -38,13 +41,12 @@ pub(crate) const OU_METALLIB: &str = env!("OU_KERNEL_METALLIB");
 pub(crate) const RANDOM_METALLIB: &str = env!("RANDOM_KERNEL_METALLIB");
 
 /// Load a pre-compiled Metal library from path
-#[allow(deprecated)]
 pub(crate) fn load_library(path: &str) -> XResult<Retained<MetalLibrary>> {
     let device = METAL_DEVICE.as_ref().map_err(Clone::clone)?;
-    let filepath = NSString::from_str(path);
+    let url = NSURL::fileURLWithPath(&NSString::from_str(path));
 
     device
-        .newLibraryWithFile_error(&filepath)
+        .newLibraryWithURL_error(&url)
         .map_err(|e| XError::Other(format!("Failed to load metallib '{}': {}", path, e)))
 }
 
@@ -61,7 +63,11 @@ pub(crate) fn get_pipeline(
 
     device
         .newComputePipelineStateWithFunction_error(&function)
-        .map_err(|e| XError::Other(format!("Pipeline creation error: {}", e)))
+        .map_err(|e| {
+            XError::Other(format!(
+                "Pipeline creation error for '{function_name}': {e}"
+            ))
+        })
 }
 
 pub(crate) fn new_shared_buffer(bytes: usize) -> XResult<Retained<MetalBuffer>> {
@@ -99,7 +105,7 @@ pub(crate) fn set_buffer(encoder: &MetalComputeEncoder, index: usize, buffer: &M
     }
 }
 
-pub(crate) fn set_scalar<T>(encoder: &MetalComputeEncoder, index: usize, value: &T) {
+pub(crate) fn set_scalar<T: Copy>(encoder: &MetalComputeEncoder, index: usize, value: &T) {
     let ptr = NonNull::from(value).cast::<c_void>();
     // SAFETY: `value` is a valid pointer for `size_of::<T>()` bytes; Metal copies
     // scalar bytes into the encoder immediately for the requested binding index.

--- a/src/gpu/metal/ou.rs
+++ b/src/gpu/metal/ou.rs
@@ -2,13 +2,15 @@ use crate::{
     FloatExt, XResult,
     gpu::{
         GPUMoment,
-        metal::{OU_METALLIB, load_library},
+        metal::{MetalLibrary, OU_METALLIB, load_library},
     },
     simulation::continuous::OrnsteinUhlenbeck as OU,
 };
+use objc2::rc::Retained;
 use std::sync::LazyLock;
 
-static LIBRARY: LazyLock<XResult<metal::Library>> = LazyLock::new(|| load_library(OU_METALLIB));
+static LIBRARY: LazyLock<XResult<Retained<MetalLibrary>>> =
+    LazyLock::new(|| load_library(OU_METALLIB));
 
 subscribe_metal_gpu_function!(LIBRARY, mean, "mean", (start_position: f32, theta: f32, sigma: f32, duration: f32, time_step: f32));
 
@@ -20,7 +22,20 @@ subscribe_metal_gpu_function!(LIBRARY, frac_raw_moment, "frac_raw_moment", (star
 
 subscribe_metal_central_moment_gpu_function!(LIBRARY, central_moment, "central_moment", (start_position: f32, theta: f32, sigma: f32, duration: f32, time_step: f32), i32);
 
-subscribe_metal_central_moment_gpu_function!(LIBRARY, frac_central_moment, "frac_central_moment", (start_position: f32, theta: f32, sigma: f32, duration: f32, time_step: f32), f32);
+subscribe_metal_frac_central_moment_gpu_function!(
+    LIBRARY,
+    frac_central_moment,
+    "frac_central_moment",
+    (
+        start_position: f32,
+        theta: f32,
+        sigma: f32,
+        duration: f32,
+        time_step: f32
+    ),
+    before_order = (),
+    after_order = (start_position, theta, sigma, duration, time_step)
+);
 
 impl<T: FloatExt> GPUMoment for OU<T> {
     fn central_moment_gpu(

--- a/src/gpu/metal/random.rs
+++ b/src/gpu/metal/random.rs
@@ -160,3 +160,38 @@ pub fn metalrandexp(n: usize) -> XResult<Vec<f32>> {
 
     Ok(read_buffer_vec_f32(&out_buffer, n))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metal_uniform_rng_returns_finite_values_in_range() {
+        let values = metalrands(128).unwrap();
+        assert_eq!(values.len(), 128);
+        assert!(values.iter().all(|value| value.is_finite()));
+        assert!(values.iter().all(|value| *value > 0.0 && *value <= 1.0));
+    }
+
+    #[test]
+    fn metal_normal_rng_returns_finite_values() {
+        let values = metalrandn(128, 0.0, 1.0).unwrap();
+        assert_eq!(values.len(), 128);
+        assert!(values.iter().all(|value| value.is_finite()));
+    }
+
+    #[test]
+    fn metal_exp_rng_returns_finite_non_negative_values() {
+        let values = metalrandexp(128).unwrap();
+        assert_eq!(values.len(), 128);
+        assert!(values.iter().all(|value| value.is_finite()));
+        assert!(values.iter().all(|value| *value >= 0.0));
+    }
+
+    #[test]
+    fn metal_standard_stable_rng_returns_finite_values() {
+        let values = standard_stable_rands(1.5, 0.0, 128).unwrap();
+        assert_eq!(values.len(), 128);
+        assert!(values.iter().all(|value| value.is_finite()));
+    }
+}

--- a/src/gpu/metal/random.rs
+++ b/src/gpu/metal/random.rs
@@ -76,7 +76,7 @@ pub fn standard_stable_rands(alpha: f32, beta: f32, len: usize) -> XResult<Vec<f
 }
 
 /// Generate uniform random numbers in (0, 1] on Metal GPU
-pub fn metalrands(n: usize) -> XResult<Vec<f32>> {
+pub fn rand(n: usize) -> XResult<Vec<f32>> {
     let queue = METAL_QUEUE.as_ref().map_err(Clone::clone)?;
     let pipeline = UNIFORM_PIPELINE.as_ref().map_err(Clone::clone)?;
 
@@ -104,7 +104,7 @@ pub fn metalrands(n: usize) -> XResult<Vec<f32>> {
 }
 
 /// Generate normal random numbers on Metal GPU
-pub fn metalrandn(n: usize, mu: f32, sigma: f32) -> XResult<Vec<f32>> {
+pub fn randn(n: usize, mu: f32, sigma: f32) -> XResult<Vec<f32>> {
     let queue = METAL_QUEUE.as_ref().map_err(Clone::clone)?;
     let pipeline = NORMAL_PIPELINE.as_ref().map_err(Clone::clone)?;
 
@@ -134,7 +134,7 @@ pub fn metalrandn(n: usize, mu: f32, sigma: f32) -> XResult<Vec<f32>> {
 }
 
 /// Generate exponential random numbers on Metal GPU
-pub fn metalrandexp(n: usize) -> XResult<Vec<f32>> {
+pub fn randexp(n: usize) -> XResult<Vec<f32>> {
     let queue = METAL_QUEUE.as_ref().map_err(Clone::clone)?;
     let pipeline = EXP_PIPELINE.as_ref().map_err(Clone::clone)?;
 
@@ -167,7 +167,7 @@ mod tests {
 
     #[test]
     fn metal_uniform_rng_returns_finite_values_in_range() {
-        let values = metalrands(128).unwrap();
+        let values = rand(128).unwrap();
         assert_eq!(values.len(), 128);
         assert!(values.iter().all(|value| value.is_finite()));
         assert!(values.iter().all(|value| *value > 0.0 && *value <= 1.0));
@@ -175,14 +175,14 @@ mod tests {
 
     #[test]
     fn metal_normal_rng_returns_finite_values() {
-        let values = metalrandn(128, 0.0, 1.0).unwrap();
+        let values = randn(128, 0.0, 1.0).unwrap();
         assert_eq!(values.len(), 128);
         assert!(values.iter().all(|value| value.is_finite()));
     }
 
     #[test]
     fn metal_exp_rng_returns_finite_non_negative_values() {
-        let values = metalrandexp(128).unwrap();
+        let values = randexp(128).unwrap();
         assert_eq!(values.len(), 128);
         assert!(values.iter().all(|value| value.is_finite()));
         assert!(values.iter().all(|value| *value >= 0.0));

--- a/src/gpu/metal/random.rs
+++ b/src/gpu/metal/random.rs
@@ -1,37 +1,39 @@
 use crate::{
     XResult,
     gpu::metal::{
-        METAL_DEVICE, METAL_QUEUE, RANDOM_METALLIB, get_pipeline, load_library, thread_config,
+        METAL_QUEUE, MetalLibrary, MetalPipeline, RANDOM_METALLIB, dispatch_threadgroups,
+        end_encoding, finish_command_buffer, get_pipeline, load_library, new_command_buffer,
+        new_compute_encoder, new_shared_buffer, read_buffer_vec_f32, set_buffer, set_pipeline,
+        set_scalar, thread_config,
     },
 };
-use metal::MTLResourceOptions;
+use objc2::rc::Retained;
 use rand::RngExt;
 use std::sync::LazyLock;
 
-static LIBRARY: LazyLock<XResult<metal::Library>> = LazyLock::new(|| load_library(RANDOM_METALLIB));
-static STANDARD_STABLE_PIPELINE: LazyLock<XResult<metal::ComputePipelineState>> =
-    LazyLock::new(|| {
-        let library = LIBRARY.as_ref()?;
-        get_pipeline(library, "standard_stable_rand")
-    });
-static UNIFORM_PIPELINE: LazyLock<XResult<metal::ComputePipelineState>> = LazyLock::new(|| {
-    let library = LIBRARY.as_ref()?;
+static LIBRARY: LazyLock<XResult<Retained<MetalLibrary>>> =
+    LazyLock::new(|| load_library(RANDOM_METALLIB));
+static STANDARD_STABLE_PIPELINE: LazyLock<XResult<Retained<MetalPipeline>>> = LazyLock::new(|| {
+    let library = LIBRARY.as_ref().map_err(Clone::clone)?;
+    get_pipeline(library, "standard_stable_rand")
+});
+static UNIFORM_PIPELINE: LazyLock<XResult<Retained<MetalPipeline>>> = LazyLock::new(|| {
+    let library = LIBRARY.as_ref().map_err(Clone::clone)?;
     get_pipeline(library, "randuniform")
 });
-static NORMAL_PIPELINE: LazyLock<XResult<metal::ComputePipelineState>> = LazyLock::new(|| {
-    let library = LIBRARY.as_ref()?;
+static NORMAL_PIPELINE: LazyLock<XResult<Retained<MetalPipeline>>> = LazyLock::new(|| {
+    let library = LIBRARY.as_ref().map_err(Clone::clone)?;
     get_pipeline(library, "randnormal")
 });
-static EXP_PIPELINE: LazyLock<XResult<metal::ComputePipelineState>> = LazyLock::new(|| {
-    let library = LIBRARY.as_ref()?;
+static EXP_PIPELINE: LazyLock<XResult<Retained<MetalPipeline>>> = LazyLock::new(|| {
+    let library = LIBRARY.as_ref().map_err(Clone::clone)?;
     get_pipeline(library, "randexp")
 });
 
 /// Generate standard stable random numbers on Metal GPU
 pub fn standard_stable_rands(alpha: f32, beta: f32, len: usize) -> XResult<Vec<f32>> {
-    let device = METAL_DEVICE.as_ref()?;
-    let queue = METAL_QUEUE.as_ref()?;
-    let pipeline = STANDARD_STABLE_PIPELINE.as_ref()?;
+    let queue = METAL_QUEUE.as_ref().map_err(Clone::clone)?;
+    let pipeline = STANDARD_STABLE_PIPELINE.as_ref().map_err(Clone::clone)?;
 
     let (inv_alpha, one_minus_alpha_div_alpha, b, s) = if (alpha - 1.0).abs() < 1e-3 {
         (0.0f32, 0.0f32, 0.0f32, 0.0f32)
@@ -44,220 +46,117 @@ pub fn standard_stable_rands(alpha: f32, beta: f32, len: usize) -> XResult<Vec<f
         (inv_alpha, one_minus_alpha_div_alpha, b, s)
     };
 
-    let out_buffer = device.new_buffer(
-        (len * std::mem::size_of::<f32>()) as u64,
-        MTLResourceOptions::StorageModeShared,
-    );
+    let out_buffer = new_shared_buffer(len * std::mem::size_of::<f32>())?;
 
     let seed: u64 = rand::rng().random();
     let len_u32 = len as u32;
 
     let (thread_groups, threads_per_group) = thread_config(len);
 
-    let command_buffer = queue.new_command_buffer();
-    let encoder = command_buffer.new_compute_command_encoder();
+    let command_buffer = new_command_buffer(queue)?;
+    let encoder = new_compute_encoder(&command_buffer)?;
 
-    encoder.set_compute_pipeline_state(pipeline);
-    encoder.set_buffer(0, Some(&out_buffer), 0);
-    encoder.set_bytes(
-        1,
-        std::mem::size_of::<f32>() as u64,
-        &alpha as *const f32 as *const _,
-    );
-    encoder.set_bytes(
-        2,
-        std::mem::size_of::<f32>() as u64,
-        &beta as *const f32 as *const _,
-    );
-    encoder.set_bytes(
-        3,
-        std::mem::size_of::<f32>() as u64,
-        &inv_alpha as *const f32 as *const _,
-    );
-    encoder.set_bytes(
-        4,
-        std::mem::size_of::<f32>() as u64,
-        &one_minus_alpha_div_alpha as *const f32 as *const _,
-    );
-    encoder.set_bytes(
-        5,
-        std::mem::size_of::<f32>() as u64,
-        &b as *const f32 as *const _,
-    );
-    encoder.set_bytes(
-        6,
-        std::mem::size_of::<f32>() as u64,
-        &s as *const f32 as *const _,
-    );
-    encoder.set_bytes(
-        7,
-        std::mem::size_of::<u32>() as u64,
-        &len_u32 as *const u32 as *const _,
-    );
-    encoder.set_bytes(
-        8,
-        std::mem::size_of::<u64>() as u64,
-        &seed as *const u64 as *const _,
-    );
+    set_pipeline(&encoder, pipeline);
+    set_buffer(&encoder, 0, &out_buffer);
+    set_scalar(&encoder, 1, &alpha);
+    set_scalar(&encoder, 2, &beta);
+    set_scalar(&encoder, 3, &inv_alpha);
+    set_scalar(&encoder, 4, &one_minus_alpha_div_alpha);
+    set_scalar(&encoder, 5, &b);
+    set_scalar(&encoder, 6, &s);
+    set_scalar(&encoder, 7, &len_u32);
+    set_scalar(&encoder, 8, &seed);
 
-    encoder.dispatch_thread_groups(thread_groups, threads_per_group);
-    encoder.end_encoding();
+    dispatch_threadgroups(&encoder, thread_groups, threads_per_group);
+    end_encoding(&encoder);
 
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    finish_command_buffer(&command_buffer)?;
 
-    let result = unsafe {
-        let ptr = out_buffer.contents() as *const f32;
-        std::slice::from_raw_parts(ptr, len).to_vec()
-    };
-
-    Ok(result)
+    Ok(read_buffer_vec_f32(&out_buffer, len))
 }
 
 /// Generate uniform random numbers in (0, 1] on Metal GPU
 pub fn metalrands(n: usize) -> XResult<Vec<f32>> {
-    let device = METAL_DEVICE.as_ref()?;
-    let queue = METAL_QUEUE.as_ref()?;
-    let pipeline = UNIFORM_PIPELINE.as_ref()?;
+    let queue = METAL_QUEUE.as_ref().map_err(Clone::clone)?;
+    let pipeline = UNIFORM_PIPELINE.as_ref().map_err(Clone::clone)?;
 
-    let out_buffer = device.new_buffer(
-        (n * std::mem::size_of::<f32>()) as u64,
-        MTLResourceOptions::StorageModeShared,
-    );
+    let out_buffer = new_shared_buffer(n * std::mem::size_of::<f32>())?;
 
     let seed: u64 = rand::rng().random();
     let len_u32 = n as u32;
 
     let (thread_groups, threads_per_group) = thread_config(n);
 
-    let command_buffer = queue.new_command_buffer();
-    let encoder = command_buffer.new_compute_command_encoder();
+    let command_buffer = new_command_buffer(queue)?;
+    let encoder = new_compute_encoder(&command_buffer)?;
 
-    encoder.set_compute_pipeline_state(pipeline);
-    encoder.set_buffer(0, Some(&out_buffer), 0);
-    encoder.set_bytes(
-        1,
-        std::mem::size_of::<u32>() as u64,
-        &len_u32 as *const u32 as *const _,
-    );
-    encoder.set_bytes(
-        2,
-        std::mem::size_of::<u64>() as u64,
-        &seed as *const u64 as *const _,
-    );
+    set_pipeline(&encoder, pipeline);
+    set_buffer(&encoder, 0, &out_buffer);
+    set_scalar(&encoder, 1, &len_u32);
+    set_scalar(&encoder, 2, &seed);
 
-    encoder.dispatch_thread_groups(thread_groups, threads_per_group);
-    encoder.end_encoding();
+    dispatch_threadgroups(&encoder, thread_groups, threads_per_group);
+    end_encoding(&encoder);
 
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    finish_command_buffer(&command_buffer)?;
 
-    let result = unsafe {
-        let ptr = out_buffer.contents() as *const f32;
-        std::slice::from_raw_parts(ptr, n).to_vec()
-    };
-
-    Ok(result)
+    Ok(read_buffer_vec_f32(&out_buffer, n))
 }
 
 /// Generate normal random numbers on Metal GPU
 pub fn metalrandn(n: usize, mu: f32, sigma: f32) -> XResult<Vec<f32>> {
-    let device = METAL_DEVICE.as_ref()?;
-    let queue = METAL_QUEUE.as_ref()?;
-    let pipeline = NORMAL_PIPELINE.as_ref()?;
+    let queue = METAL_QUEUE.as_ref().map_err(Clone::clone)?;
+    let pipeline = NORMAL_PIPELINE.as_ref().map_err(Clone::clone)?;
 
-    let out_buffer = device.new_buffer(
-        (n * std::mem::size_of::<f32>()) as u64,
-        MTLResourceOptions::StorageModeShared,
-    );
+    let out_buffer = new_shared_buffer(n * std::mem::size_of::<f32>())?;
 
     let seed: u64 = rand::rng().random();
     let len_u32 = n as u32;
 
     let (thread_groups, threads_per_group) = thread_config(n);
 
-    let command_buffer = queue.new_command_buffer();
-    let encoder = command_buffer.new_compute_command_encoder();
+    let command_buffer = new_command_buffer(queue)?;
+    let encoder = new_compute_encoder(&command_buffer)?;
 
-    encoder.set_compute_pipeline_state(pipeline);
-    encoder.set_buffer(0, Some(&out_buffer), 0);
-    encoder.set_bytes(
-        1,
-        std::mem::size_of::<u32>() as u64,
-        &len_u32 as *const u32 as *const _,
-    );
-    encoder.set_bytes(
-        2,
-        std::mem::size_of::<f32>() as u64,
-        &mu as *const f32 as *const _,
-    );
-    encoder.set_bytes(
-        3,
-        std::mem::size_of::<f32>() as u64,
-        &sigma as *const f32 as *const _,
-    );
-    encoder.set_bytes(
-        4,
-        std::mem::size_of::<u64>() as u64,
-        &seed as *const u64 as *const _,
-    );
+    set_pipeline(&encoder, pipeline);
+    set_buffer(&encoder, 0, &out_buffer);
+    set_scalar(&encoder, 1, &len_u32);
+    set_scalar(&encoder, 2, &mu);
+    set_scalar(&encoder, 3, &sigma);
+    set_scalar(&encoder, 4, &seed);
 
-    encoder.dispatch_thread_groups(thread_groups, threads_per_group);
-    encoder.end_encoding();
+    dispatch_threadgroups(&encoder, thread_groups, threads_per_group);
+    end_encoding(&encoder);
 
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    finish_command_buffer(&command_buffer)?;
 
-    let result = unsafe {
-        let ptr = out_buffer.contents() as *const f32;
-        std::slice::from_raw_parts(ptr, n).to_vec()
-    };
-
-    Ok(result)
+    Ok(read_buffer_vec_f32(&out_buffer, n))
 }
 
 /// Generate exponential random numbers on Metal GPU
 pub fn metalrandexp(n: usize) -> XResult<Vec<f32>> {
-    let device = METAL_DEVICE.as_ref()?;
-    let queue = METAL_QUEUE.as_ref()?;
-    let pipeline = EXP_PIPELINE.as_ref()?;
+    let queue = METAL_QUEUE.as_ref().map_err(Clone::clone)?;
+    let pipeline = EXP_PIPELINE.as_ref().map_err(Clone::clone)?;
 
-    let out_buffer = device.new_buffer(
-        (n * std::mem::size_of::<f32>()) as u64,
-        MTLResourceOptions::StorageModeShared,
-    );
+    let out_buffer = new_shared_buffer(n * std::mem::size_of::<f32>())?;
 
     let seed: u64 = rand::rng().random();
     let len_u32 = n as u32;
 
     let (thread_groups, threads_per_group) = thread_config(n);
 
-    let command_buffer = queue.new_command_buffer();
-    let encoder = command_buffer.new_compute_command_encoder();
+    let command_buffer = new_command_buffer(queue)?;
+    let encoder = new_compute_encoder(&command_buffer)?;
 
-    encoder.set_compute_pipeline_state(pipeline);
-    encoder.set_buffer(0, Some(&out_buffer), 0);
-    encoder.set_bytes(
-        1,
-        std::mem::size_of::<u32>() as u64,
-        &len_u32 as *const u32 as *const _,
-    );
-    encoder.set_bytes(
-        2,
-        std::mem::size_of::<u64>() as u64,
-        &seed as *const u64 as *const _,
-    );
+    set_pipeline(&encoder, pipeline);
+    set_buffer(&encoder, 0, &out_buffer);
+    set_scalar(&encoder, 1, &len_u32);
+    set_scalar(&encoder, 2, &seed);
 
-    encoder.dispatch_thread_groups(thread_groups, threads_per_group);
-    encoder.end_encoding();
+    dispatch_threadgroups(&encoder, thread_groups, threads_per_group);
+    end_encoding(&encoder);
 
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    finish_command_buffer(&command_buffer)?;
 
-    let result = unsafe {
-        let ptr = out_buffer.contents() as *const f32;
-        std::slice::from_raw_parts(ptr, n).to_vec()
-    };
-
-    Ok(result)
+    Ok(read_buffer_vec_f32(&out_buffer, n))
 }

--- a/src/random/uniform.rs
+++ b/src/random/uniform.rs
@@ -224,7 +224,7 @@ mod tests {
     fn test_unit_randoms() {
         let n = 1000000;
         let randoms = standard_rands(n);
-        assert_eq!(randoms.len() as usize, n);
+        assert_eq!(randoms.len(), n);
         assert!(randoms.iter().all(|x| (0.0..1.0).contains(x)));
     }
 


### PR DESCRIPTION
## Summary

Replaces the deprecated `metal-rs` bindings with the actively maintained `objc2` family (`objc2`, `objc2-metal`, `objc2-foundation`, `dispatch2`) and ships the result as **v0.12.0**.

- **Port the Metal backend to objc2** — device/queue/library/pipeline handling, buffer and encoder helpers, and all four GPU modules (`bm`, `levy`, `ou`, `random`) rewritten against `objc2-metal`.
- **Embed compiled Metal libraries in the binary** — `.metallib` artifacts are now baked in via `include_bytes!` and loaded with `newLibraryWithData`, instead of storing the `OUT_DIR` path and reading the file at runtime. The binary is now self-contained, matching how the CUDA backend already embeds its PTX. Previously `cargo clean`, moving the binary, or distributing it broke GPU calls at runtime.
- **Unify random fn names across CUDA and Metal** so both backends expose the same `gpu::random` API.
- **Add Metal GPU benchmarks** for the uniform, normal, exponential, and stable distributions, mirroring the existing CUDA-gated benches.
- **Add Metal random smoke tests** covering uniform/normal/exp/stable RNG.
- Misc: add project `CLAUDE.md`, bump MSRV to 1.88, drop `metal` from default features.

## Verification

- `cargo clippy --features metal --all-targets -- -D warnings` — clean
- `cargo test --features metal` — Metal tests pass (7/7)
- `cargo build --benches --features metal` — compiles
- Embedding confirmed: deleted all `*.metallib` files from the build directory and re-ran the already-compiled test binary — still 7/7 pass (the old path-based loader would have failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)