### PR TITLE
fix(docs): correct rustdoc-args order for docs.rs (v0.12.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ name = "diffusionx"
 readme = "README.md"
 repository = "https://github.com/tangxiangong/diffusionx"
 rust-version = "1.88"
-version = "0.12.0"
+version = "0.12.1"
 
 [package.metadata.docs.rs]
 features = ["io", "visualize"]
-rustdoc-args = ["--cfg", "--html-in-header", "./docs-header.html", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "./docs-header.html"]
 
 [lib]
 doctest = false


### PR DESCRIPTION
## Summary

Fixes the docs.rs build failure for `diffusionx`.

The `rustdoc-args` array in `[package.metadata.docs.rs]` paired flags with
the wrong values:

```toml
# before
rustdoc-args = ["--cfg", "--html-in-header", "./docs-header.html", "docsrs"]
# after
rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "./docs-header.html"]
```

With the old order, `rustdoc` interpreted `--cfg --html-in-header` as
`--cfg` consuming `--html-in-header` as its value, leaving `./docs-header.html`
and `docsrs` as stray positional file operands. Since `rustdoc --lib` already
has the crate root, docs.rs failed with:

```
error: too many file operands
error: could not document `diffusionx`
```

This only surfaced on docs.rs because `[package.metadata.docs.rs]` is ignored
by local `cargo doc`.

## Changes

- Reorder `rustdoc-args` so each flag is followed by its own value
- Bump version `0.12.0` → `0.12.1`

## Verification

Built locally simulating the docs.rs environment:

```sh
RUSTDOCFLAGS="--cfg docsrs --html-in-header ./docs-header.html" \
  cargo +nightly doc --no-deps --lib --features "io visualize"
```

Result: `Finished` / `Generated target/doc/diffusionx/index.html` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)